### PR TITLE
Finalizer of ShellScript backend should not have a reference to itself.

### DIFF
--- a/lib/specinfra/backend/shellscript.rb
+++ b/lib/specinfra/backend/shellscript.rb
@@ -5,15 +5,24 @@ module SpecInfra
     class ShellScript < Base
       def initialize
         @lines = [ "#!/bin/sh", "" ]
-        ObjectSpace.define_finalizer(self) {
-          File.write("spec.sh", @lines.join("\n"))
-        }
+        ObjectSpace.define_finalizer(self, Writer.new("spec.sh", @lines))
       end
 
       def run_command(cmd, opts={})
         @lines << cmd
         { :stdout => nil, :stderr => nil,
           :exit_status => 0, :exit_signal => nil }
+      end
+
+      class Writer
+        def initialize(file, lines)
+          @file = file
+          @lines = lines
+        end
+
+        def call(*args)
+          File.write(@file, @lines.join("\n"))
+        end
       end
     end
   end


### PR DESCRIPTION
With the following code:

``` ruby
        ObjectSpace.define_finalizer(self) {
          File.write("spec.sh", @lines.join("\n"))
        }
```

the proc captures `self` and `self` is never finalized.
(Actually, this program works properly because `self` is finalized when the program finishes)

See Also (Japanese): http://docs.ruby-lang.org/ja/2.0.0/method/ObjectSpace/m/define_finalizer.html
