### PR TITLE
add freebsd specific get_mode method

### DIFF
--- a/lib/specinfra/command/freebsd.rb
+++ b/lib/specinfra/command/freebsd.rb
@@ -18,6 +18,10 @@ module SpecInfra
         regexp = "^#{mode}$"
         "stat -f%Lp #{escape(file)} | grep -- #{escape(regexp)}"
       end
+
+      def get_mode(file)
+        "stat -f%Lp #{escape(file)}"
+      end
     end
   end
 end


### PR DESCRIPTION
lib/specinfra/backend/exec.rb use get_mode method
for FreeBSD it use stat -c option that does not exist in stat util, so it should be stat -f%Lp
