### PR TITLE
fix get_file_content method

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -290,7 +290,7 @@ module SpecInfra
       end
 
       def get_file_content(file)
-        "cat #{file} 2> || echo -n"
+        "cat #{file} 2> /dev/null || echo -n"
       end
 
       def check_container(container)


### PR DESCRIPTION
Example:
describe file('/usr/local/etc/nginx/upstreams.conf') do
  it { should be_file }
  its(:content) { should match /upstream/ }
end
match in this example will be false positive, because of stderr that include file name.
I think in case if we don't have file for this matcher we should return error or empty string.
With this fix it will return empty string.
