### PR TITLE
Allow to not use `sudo` with SSH

### DIFF
--- a/lib/specinfra.rb
+++ b/lib/specinfra.rb
@@ -21,6 +21,7 @@ if defined?(RSpec)
     c.add_setting :host,          :default => nil
     c.add_setting :ssh,           :default => nil
     c.add_setting :sudo_password, :default => nil
+    c.add_setting :sudo_disable,  :default => false
     c.add_setting :winrm,         :default => nil
     SpecInfra.configuration.defaults.each { |k, v| c.add_setting k, :default => v }
     c.before :each do

--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -20,7 +20,9 @@ module SpecInfra
 
       def build_command(cmd)
         cmd = super(cmd)
-        if SpecInfra.configuration.ssh.options[:user] != 'root'
+        user = SpecInfra.configuration.ssh.options[:user]
+        sudo_disable = SpecInfra.configuration.sudo_disable
+        if user != 'root' && !sudo_disable
           cmd = "#{sudo} #{cmd}"
           cmd.gsub!(/(\&\&\s*!?\(?\s*)/, "\\1#{sudo} ")
           cmd.gsub!(/(\|\|\s*!?\(?\s*)/, "\\1#{sudo} ")
@@ -32,7 +34,8 @@ module SpecInfra
         cmd = super(cmd)
         user = SpecInfra.configuration.ssh.options[:user]
         pre_command = SpecInfra.configuration.pre_command
-        if pre_command && user != 'root'
+        sudo_disable = SpecInfra.configuration.sudo_disable
+        if pre_command && user != 'root' && !sudo_disable
           cmd = "#{sudo} #{cmd}"
         end
         cmd

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -1,7 +1,7 @@
 module SpecInfra
   module Configuration
     class << self
-      VALID_OPTIONS_KEYS = [:path, :pre_command, :stdout, :stderr, :sudo_path, :pass_prompt].freeze
+      VALID_OPTIONS_KEYS = [:path, :pre_command, :stdout, :stderr, :sudo_path, :sudo_disable, :pass_prompt].freeze
 
       def defaults
         VALID_OPTIONS_KEYS.inject({}) { |o, k| o.merge!(k => send(k)) }


### PR DESCRIPTION
We add an option `sudo_disable` to not use `sudo` when the user is not
root. Since, most of the time, `sudo` is not needed, most tests can work
this way.

Tests for this feature will be done in `serverspec` repository.
