### PR TITLE
fix issue on Ubuntu with check_running for courier-imap service

### DIFF
--- a/lib/specinfra/command/ubuntu.rb
+++ b/lib/specinfra/command/ubuntu.rb
@@ -2,7 +2,7 @@ module SpecInfra
   module Command
     class Ubuntu < Debian
       def check_running(service)
-        "service #{escape(service)} status | grep 'running'"
+        "service #{escape(service)} status && service #{escape(service)} status | grep 'running'"
       end
     end
   end


### PR DESCRIPTION
When specifying the os_by_host as Ubuntu, the 'check runnning' of courier-imap service (Ubuntu 12.04 tested) is not working.
indeed, the return of `service courier-imap status` is the following:
- when running: `* Courier IMAP server is running`
- when not running: `* Courier IMAP server is not running`
