### PR TITLE
Add a method to get a process parameter.

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -113,6 +113,10 @@ module SpecInfra
         "ps aux | grep -w -- #{escape(process)} | grep -qv grep"
       end
 
+      def get_process(process, param)
+        "ps -C #{escape(process)} -o #{escape(param)}= | head -1"
+      end
+
       def check_file_contain(file, expected_pattern)
         "#{check_file_contain_with_regexp(file, expected_pattern)} || #{check_file_contain_with_fixed_strings(file, expected_pattern)}"
       end


### PR DESCRIPTION
This will only match the first process as we don't really know how to
aggregate the results. A parameter can be anything accepted as `-o` flag
of `ps`. For example `pid`, `args` and `vsz` are valid parameters.
