### PR TITLE
Integrate command method arguments to ``targert, option_hash``

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -113,8 +113,8 @@ module SpecInfra
         "ps aux | grep -w -- #{escape(process)} | grep -qv grep"
       end
 
-      def get_process(process, param)
-        "ps -C #{escape(process)} -o #{escape(param)}= | head -1"
+      def get_process(process, opts)
+        "ps -C #{escape(process)} -o #{opts[:format]} | head -1"
       end
 
       def check_file_contain(file, expected_pattern)


### PR DESCRIPTION
I'd like to integrate command method arguments to the form `target, option_hash`.
So I change the arguments of newly added method to this form.
