### PR TITLE
delete CR(carriage return) from check_routing_table

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -164,7 +164,9 @@ module SpecInfra
         ret = run_command(commands.check_routing_table(expected_attr[:destination]))
         return false if ret[:exit_status] != 0
 
-        ret[:stdout] =~ /^(\S+)(?: via (\S+))? dev (\S+).+\r\n(?:default via (\S+))?/
+        ret[:stdout].gsub!(/\r\n/, "\n")
+
+        ret[:stdout] =~ /^(\S+)(?: via (\S+))? dev (\S+).+\n(?:default via (\S+))?/
         actual_attr = {
           :destination => $1,
           :gateway     => $2 ? $2 : $4,


### PR DESCRIPTION
When I tried to test routing_table from Ubuntu 12.10 64bit to CentOS 6.5 x86_64 via SSH, it finished failure.
I printed out "ret[:stdout]", it has no "\r".
