### PR TITLE
Support RSpec 3

### DIFF
--- a/lib/specinfra.rb
+++ b/lib/specinfra.rb
@@ -25,6 +25,7 @@ if defined?(RSpec)
     SpecInfra.configuration.defaults.each { |k, v| c.add_setting k, :default => v }
     c.before :each do
       if respond_to?(:backend) && backend.respond_to?(:set_example)
+        example = RSpec.respond_to?(:current_example) ? RSpec.current_example : self.example
         backend.set_example(example)
       end
     end

--- a/lib/specinfra/helper/configuration.rb
+++ b/lib/specinfra/helper/configuration.rb
@@ -2,6 +2,7 @@ module SpecInfra
   module Helper
     module Configuration
       def subject
+        example = RSpec.respond_to?(:current_example) ? RSpec.current_example : self.example
         example.metadata[:subject] = described_class
         build_configurations
         super


### PR DESCRIPTION
This change allows to use serverspec with RSpec 3. Of course, the support for RSpec 2 is kept.

Fortunately serverspec is not using any of [deprecated API of the custom matcher DSL in RSpec 3](https://github.com/yujinakayama/transpec/blob/v1.6.1/README.md#custom-matcher-dsl), so no change is required in serverspec.
