### PR TITLE
ssh copy_file

### DIFF
--- a/lib/specinfra.rb
+++ b/lib/specinfra.rb
@@ -20,6 +20,7 @@ if defined?(RSpec)
     c.add_setting :os,            :default => nil
     c.add_setting :host,          :default => nil
     c.add_setting :ssh,           :default => nil
+    c.add_setting :scp,           :default => nil
     c.add_setting :sudo_password, :default => nil
     c.add_setting :winrm,         :default => nil
     SpecInfra.configuration.defaults.each { |k, v| c.add_setting k, :default => v }

--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -42,7 +42,13 @@ module SpecInfra
       end
 
       def copy_file(from, to)
-        raise NotImplementedError.new
+        scp = SpecInfra.configuration.scp
+        begin
+          scp.upload!(from, to)
+        rescue => e
+          return false
+        end
+        true
       end
 
       private


### PR DESCRIPTION
Continued from https://github.com/serverspec/specinfra/pull/32

Added SSH #copy_file method which uses scp.
