### PR TITLE
Win32_Product call replaced with registry key search

### DIFF
--- a/lib/specinfra/backend/powershell/support/find_installed_application.ps1
+++ b/lib/specinfra/backend/powershell/support/find_installed_application.ps1
@@ -1,7 +1,21 @@
 function FindInstalledApplication
 {
   param($appName, $appVersion)
-  $selectionCriteria = "(Name like '$appName' or PackageName like '$appName') and InstallState = 5"
-  if ($appVersion -ne $null) { $selectionCriteria += " and version = '$appVersion'"}
-  Get-WmiObject Win32_Product -filter $selectionCriteria
+    
+  if ((Get-WmiObject win32_operatingsystem).OSArchitecture -notlike '64-bit')  
+  { 
+      $keys= (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*') 
+  }  
+    else  
+  { 
+      $keys = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*') 
+  }   
+
+  if ($appVersion -eq $null) { 
+   $keys | Where-Object {$_.name -like $appName -or $_.PSChildName -like $appName}
+  }
+  else{
+   $keys | Where-Object {$_.name -like $appName -or $_.PSChildName -like $appName  } | Where-Object {$_.DisplayVersion -eq $appVersion}
+  }
 }
+


### PR DESCRIPTION
1) Get-WmiObject Win32_Product is REALLY slow when you have lots of programs installed
2) The Win32_Product class works by enumerating every MSI package that is installed on the system. When a package is touched, it performs a reconfiguration where the application is validated (and repaired if found to be inconsistent with the original MSI). Serverspec should not be modifying the target machine, only testing its state.
3) The list that Win32_product produces is incomplete. For example, it is unable to find Google Chrome when it is present in "Add/Remove programs"
