### PR TITLE
Cache results of ListWindowsFeatures for 2 minutes

### DIFF
--- a/lib/specinfra/backend/powershell/support/list_windows_features.ps1
+++ b/lib/specinfra/backend/powershell/support/list_windows_features.ps1
@@ -1,5 +1,14 @@
 function ListWindowsFeatures
 {    
+    $cachepath =  "${env:temp}/ListWindowsFeatures.xml"
+    $maxAge = 2
+
+    $cache =  Get-Item $cachepath -erroraction SilentlyContinue
+
+    if($cache -ne $null -and ((get-date) - $cache.LastWriteTime).minutes -lt $maxage){
+        return Import-Clixml $cachepath
+    }
+    else{
         try
         {
             $dism = DISM /Online /Get-Features /Format:List | Where-Object {$_}     
@@ -21,6 +30,8 @@ function ListWindowsFeatures
                 }
             }
 
+            $feature | Export-Clixml $cachepath
+
             return $feature
         }
         catch
@@ -28,4 +39,5 @@ function ListWindowsFeatures
             Throw
         }
 
+    }
 }


### PR DESCRIPTION
This pull request reduces the amount of calls to dism.exe when running specs that describes more than 1 windows feature. It can take upwards of 10 seconds to return the list, and only 1 instance of dism.exe can be run at a time. dism.exe blocks other instances of dism.exe while it's running, which could cause problems if running serverspec tasks in parallel.

The feature list is now generated using dism.exe then cached for 2 minutes. During those 2 minutes, subsequent invocations of the ListWindowsFeatures function will return the cached feature list, which will return a result within 1 second.

This should help alleviate the blocking problem. In addition, caching reduced the time it took for me to test 50 windows features from 12 minutes down to 2 minutes. 
