### PR TITLE
Check the Windows metadata version of a file

### DIFF
--- a/lib/specinfra/command/windows.rb
+++ b/lib/specinfra/command/windows.rb
@@ -212,6 +212,11 @@ module SpecInfra
  
        end
 
+       def check_file_version(name,version)
+          cmd = "((Get-Command '#{name}').FileVersionInfo.ProductVersion -eq '#{version}') -or ((Get-Command '#{name}').FileVersionInfo.FileVersion -eq '#{version}')"
+          Backend::PowerShell::Command.new { exec cmd }
+       end
+
       private
 
       def item_has_attribute item, attribute


### PR DESCRIPTION
Adds the ability to check if a dll/exe's product/file version matches a version string

```
describe file("C:/Windows/System32/aaclient.dll") do
    it{ should be_file }
    it{ should be_version("6.2.9200.16398") }
end 
```
