### PR TITLE
Test run hangs if checking a registry key with a DWORD value that contains less than 8 characters

### DIFF
--- a/lib/specinfra/command/windows.rb
+++ b/lib/specinfra/command/windows.rb
@@ -234,7 +234,7 @@ module SpecInfra
           byte_array = [property[:value]].pack('H*').bytes.to_a
           "([byte[]] #{byte_array.join(',')})"
         when :type_dword
-          [property[:value].scan(/[0-9a-f]{2}/i).reverse.join].pack("H*").unpack("l").first
+          [property[:value].rjust(8, '0').scan(/[0-9a-f]{2}/i).reverse.join].pack("H*").unpack("l").first
         when :type_qword
           property[:value].hex
         else


### PR DESCRIPTION
Previously, the following test would hang the whole test run until it was manually stopped

```
describe windows_registry_key('HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\aspnet_state\\Parameters') do
  it { should have_property_value('AllowRemoteConnection', :type_dword, '0') }
end
```

This is because the test expects property[:value] to be a hexidecimal string that contains 8 characters, to match the DWORD data type. 

This pull request sets the correct string length by padding the missing zeros, preventing the hanging behaviour.

Both of the following have_property_value expectations are now valid.

```
describe windows_registry_key('HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\aspnet_state\\Parameters') do
  it { should have_property_value('AllowRemoteConnection', :type_dword, '0') }
  it { should have_property_value('AllowRemoteConnection', :type_dword, '00000000') }
end
```
