### PR TITLE
Add boundaries to the check_link target name match string

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -173,7 +173,7 @@ module SpecInfra
       end
 
       def check_link(link, target)
-        "stat -c %N #{escape(link)} | grep -- #{escape(target)}"
+        "stat -c %N #{escape(link)} | grep -- \"-> \\`#{escape(target)}'\""
       end
 
       def check_installed_by_gem(name, version=nil)


### PR DESCRIPTION
Currently, specifying /var/log/messages as the intended target causes the test to pass even if the actual target is /mnt/var/log/messages.  This fixes that problem.
