### PR TITLE
[WIP] substitute pkgng for pkg_info, pkg_add, and such

### DIFF
--- a/lib/specinfra/command/freebsd.rb
+++ b/lib/specinfra/command/freebsd.rb
@@ -30,6 +30,10 @@ module SpecInfra
       def install(package)
         "pkg install -y #{escape(package)}"
       end
+
+      def get_package_version(package)
+          "pkg query %v #{escape(package)}"
+      end
     end
   end
 end


### PR DESCRIPTION
"pkgng" is the new package manager. see
http://www.freebsd.org/doc/en/books/handbook/pkgng-intro.html

I suppose it should use pkgng instead of pkg_info, pkg_add, and such. pkgng
supports FreeBSD 9.1 over, and moreover, pkg_info and such have been removed
since FreeBSD 10.0-CURRENT.

see also: https://github.com/serverspec/serverspec/pull/348
