### PR TITLE
Check the exact startup mode of a windows service

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -79,6 +79,14 @@ module SpecInfra
         raise NotImplementedError.new
       end
 
+      def check_service_installed(service)
+        raise NotImplementedError.new
+      end
+
+      def check_service_start_mode(service, mode)
+        raise NotImplementedError.new
+      end
+
       def check_listening(port)
         regexp = ":#{port} "
         "netstat -tunl | grep -- #{escape(regexp)}"

--- a/lib/specinfra/command/windows.rb
+++ b/lib/specinfra/command/windows.rb
@@ -106,6 +106,20 @@ module SpecInfra
         end
       end
 
+      def check_service_installed(service)
+        Backend::PowerShell::Command.new do
+          using 'find_service.ps1'
+          exec "@(FindService -name '#{service}').count -gt 0"
+        end
+      end
+
+      def check_service_start_mode(service, mode)
+        Backend::PowerShell::Command.new do
+          using 'find_service.ps1'
+          exec  "'#{mode}' -match (FindService -name '#{service}').StartMode -and (FindService -name '#{service}') -ne $null"
+        end
+      end
+
       def check_enabled(service, level=nil)
         Backend::PowerShell::Command.new do
           using 'find_service.ps1'


### PR DESCRIPTION
Usage;

``` ruby
describe service("Winmgmt") do
    it{ should have_start_mode("Manual") }
end
```

Additionally I've implemented "be_installed" on the Service resource - just to check that the service has been registered, regardless of its startmode or current run state.

``` ruby
describe service("Winmgmt") do
    it{ should be_installed }
end
```
