### PR TITLE
Add the wildcard INADDR_ANY [0.0.0.0]

### DIFF
--- a/lib/specinfra/backend/powershell/support/is_port_listening.ps1
+++ b/lib/specinfra/backend/powershell/support/is_port_listening.ps1
@@ -3,6 +3,7 @@ function IsPortListening
   param($portNumber, $protocol)
   $netstatOutput = netstat -an | Out-String
   $networkIPs = (Get-WmiObject Win32_NetworkAdapterConfiguration | ? {$_.IPEnabled}) | %{ $_.IPAddress[0] }
+  [array] $networkIPs += "0.0.0.0"
   foreach ($ipaddress in $networkIPs)
   {
     $matchExpression = ("$ipaddress" + ":" + $portNumber)


### PR DESCRIPTION
Let the function find a listen port when we have applications listening on INADDR_ANY [wildcard - 0.0.0.0]. This means that the application will be heard on all local interfaces and can connect to the port on any of them.
