### PR TITLE
Add get_file_content to windows command

### DIFF
--- a/lib/specinfra/command/windows.rb
+++ b/lib/specinfra/command/windows.rb
@@ -66,6 +66,10 @@ module SpecInfra
         end
       end
 
+      def get_file_content(file)
+        "[Io.File]::ReadAllText('#{file}')"
+      end
+
       def check_access_by_user(file, user, access)
         case access
         when 'r'


### PR DESCRIPTION
Add get_file_content to windowd command to allow `its(:content) { should ... }` on windows.
