### PR TITLE
Add architecture option that switches x86/x64 powershell

### DIFF
--- a/lib/specinfra.rb
+++ b/lib/specinfra.rb
@@ -24,6 +24,7 @@ if defined?(RSpec)
     c.add_setting :scp,           :default => nil
     c.add_setting :sudo_password, :default => nil
     c.add_setting :winrm,         :default => nil
+    c.add_setting :architecture,  :default => :x86_64
     SpecInfra.configuration.defaults.each { |k, v| c.add_setting k, :default => v }
     c.before :each do
       if respond_to?(:backend) && backend.respond_to?(:set_example)


### PR DESCRIPTION
Allow to select x86 or x64 powershell to execute commands.

The architecture (`:x86_64` or `:i386`) can be specified by RSpec(SpecInfra) configuration or metadata (`:86_64` is default).

``` ruby
# specified by RSpec configuration
RSpec.configure do |c|
  c.architecture = :x86_64
end

# specified by metadata
describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\SOME_SOFTWEARE'), architecture: :i386 do
  # actually access 'HKLM\SOFTWARE\Wow6432Node\SOME_SOFTWARE' in x64 OS
  ...
end
```
