### PR TITLE
Reordering ping parameters to work with AIX.

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -39,7 +39,7 @@ module SpecInfra
 
       def check_reachable(host, port, proto, timeout)
         if port.nil?
-          "ping -n #{escape(host)} -w #{escape(timeout)} -c 2"
+          "ping -w #{escape(timeout)} -c 2 -n #{escape(host)}"
         else
           "nc -vvvvz#{escape(proto[0].chr)} #{escape(host)} #{escape(port)} -w #{escape(timeout)}"
         end


### PR DESCRIPTION
For GNU/Linux (at least RHEL 6), the ping parameters order doesn't
matter. But for AIX I get an error with the original order:

$ sudo ping -n 127.0.0.1 -w 3 -c 2
0821-077 ping: illegal packet size.

and it works if the parameters order just get rearranged:

$ sudo ping -w 3 -c 2 -n 127.0.0.1
PING 127.0.0.1: (127.0.0.1): 56 data bytes
64 bytes from 127.0.0.1: icmp_seq=0 ttl=255 time=0 ms
64 bytes from 127.0.0.1: icmp_seq=1 ttl=255 time=0 ms

--- 127.0.0.1 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 0/0/0 ms
