### PR TITLE
Coerce method name to String before checking

### DIFF
--- a/lib/specinfra/backend/base.rb
+++ b/lib/specinfra/backend/base.rb
@@ -24,7 +24,7 @@ module SpecInfra
 
       # Default action is to call check_zero with args
       def method_missing(meth, *args, &block)
-        if meth =~ /^check/
+        if meth.to_s =~ /^check/
           check_zero(meth, *args)
         else
           run_command(commands.send(meth, *args))


### PR DESCRIPTION
For working with Ruby 1.8
