### PR TITLE
Block any powershell progress bar output

### DIFF
--- a/lib/specinfra/backend/powershell/script_helper.rb
+++ b/lib/specinfra/backend/powershell/script_helper.rb
@@ -53,6 +53,7 @@ EOF
             script = add_pre_command(script)
             <<-EOF
 $exitCode = 1
+$ProgressPreference = "SilentlyContinue"
 try {
   #{ps_functions.join("\n")}
   $success = (#{script})


### PR DESCRIPTION
I was having issues with some tests consistently not passing even though they "should" be passing, and the test returned a successful exit code of "0".

From the console log;

```
...
  $success = ((FindIISAppPool -name 'DefaultAppPool').managedRuntimeVersion -match 'v2.0')
  if ($success -is [Boolean] -and $success) { $exitCode = 0 }
} catch {
  Write-Output $_.Exception.Message
}
Write-Output "Exiting with code: $exitCode"
exit $exitCode
       Exiting with code: 0

#< CLIXML

<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>
       expected #has_dotnet_version?("2.0") to return true, got false
```

It seems that if powershell tries to showing a progress bar at some point during the test (as shown in the weird Powershell CLIXML output), the test fails. Changing the variable $ProgressPreference to "SilentlyContinue" will suppress the progress bar, which makes my failing tests pass.
