### PR TITLE
Support Arch Linux

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -233,6 +233,8 @@ module SpecInfra
           else
             { :family => 'FreeBSD', :release => nil }
           end
+        elsif run_command('uname -sr').stdout =~ /Arch/i
+          { :family => 'Arch', :release => nil }
         else
           { :family => 'Base', :release => nil }
         end

--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -2,6 +2,7 @@ require "specinfra/command/base"
 
 # Linux
 require "specinfra/command/linux"
+require "specinfra/command/arch"
 require "specinfra/command/debian"
 require "specinfra/command/ubuntu"
 require "specinfra/command/gentoo"

--- a/lib/specinfra/command/arch.rb
+++ b/lib/specinfra/command/arch.rb
@@ -1,0 +1,37 @@
+module SpecInfra
+  module Command
+    class Arch < Linux
+      def check_access_by_user(file, user, access)
+        "runuser -s /bin/sh -c \"test -#{access} #{file}\" #{user}"
+      end
+
+      def check_enabled(service, target="multi-user.target")
+        "systemctl --plain list-dependencies #{target} | grep '^#{escape(service)}.service$'"
+      end
+
+      def check_running(service)
+        "systemctl is-active #{escape(service)}.service"
+      end
+
+      def check_installed(package,version=nil)
+        if version
+          "pacman -Q | grep #{escape(package)} #{espace(version)}"
+        else
+          "pacman -Q | grep #{escape(package)}"
+        end
+      end
+
+      def sync_repos
+        "pacman -Syy"
+      end
+
+      def install(package)
+        "pacman -S --noconfirm #{package}"
+      end
+
+      def get_package_version(package, opts=nil)
+        "pacman -Qi #{package} | grep Version | awk '{print $3}'"
+      end
+    end
+  end
+end

--- a/lib/specinfra/helper/os.rb
+++ b/lib/specinfra/helper/os.rb
@@ -3,6 +3,7 @@ module SpecInfra
     [
       'Base',
       'AIX',
+      'Arch',
       'Darwin',
       'Debian',
       'FreeBSD',


### PR DESCRIPTION
This PR is to support Arch Linux which is released after 2013-02-04 (cf. [Arch Linux - News: Final sysvinit deprecation warning](https://www.archlinux.org/news/final-sysvinit-deprecation-warning/Arch)).
Arch uses `pacman` as its package manager and `systemd` as a default system and service manager.
