### PR TITLE
add check_file_contain_lines: matcher for fixed-line sequence

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -161,6 +161,17 @@ module SpecInfra
         "#{sed} | #{checker_with_regexp} || #{sed} | #{checker_with_fixed}"
       end
 
+      def check_file_contain_lines(file, expected_lines, from=nil, to=nil)
+        require 'digest/md5'
+        from ||= '1'
+        to ||= '$'
+        sed = "sed -n #{escape(from)},#{escape(to)}p #{escape(file)}"
+        head_line = expected_lines.first.chomp
+        lines_checksum = Digest::MD5.hexdigest(expected_lines.map(&:chomp).join("\n") + "\n")
+        afterwards_length = expected_lines.length - 1
+        "#{sed} | grep -A #{escape(afterwards_length)} -F -- #{escape(head_line)} | md5sum | grep -qiw -- #{escape(lines_checksum)}"
+      end
+
       def check_mode(file, mode)
         regexp = "^#{mode}$"
         "stat -c %a #{escape(file)} | grep -- #{escape(regexp)}"


### PR DESCRIPTION
Current set of commands like `check_file_contain_*` cannot check whether 2 or more lines are exists as sequence exactly, or not.

```
# expected_lines.txt
Label section1
    attr1 value_one
    attr2 value_two

# false_positive.txt
Label section1
    attr1 wrong_value1
Label section2
    attr1 value_one
    attr2 value_two
```

To check `attr2 value_two` belongs to `section1`, we need exact sequence matching for 2 or more lines.
This patch addes `check_file_contain_lines` to test to match the heading line and following specified lines are exactly same with specified lines by md5sum.
