### PR TITLE
OSArchitecture of Windows7 Japanese doesn't return a value '64-bit'.

### DIFF
--- a/lib/specinfra/backend/powershell/support/find_installed_application.ps1
+++ b/lib/specinfra/backend/powershell/support/find_installed_application.ps1
@@ -2,7 +2,7 @@ function FindInstalledApplication
 {
   param($appName, $appVersion)
     
-  if ((Get-WmiObject win32_operatingsystem).OSArchitecture -notlike '64-bit')  
+  if ((Get-WmiObject win32_operatingsystem).OSArchitecture -notmatch '64')  
   { 
       $keys= (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*') 
   }  


### PR DESCRIPTION
"package should be_installed" doesn't work correctly on Windows 64bit _Japanese_ OS.

"(Get-WmiObject win32_operatingsystem).OSArchitecture" on Windows 7 64bit Japanese returns "64 ビット".
It causes serversepc on Windows 64bit doesn't look at an appropriate registry,
when testing package should be_installed.

Windows 7 64bit Japanese shows:
PS C:\tmp> (Get-WmiObject win32_operatingsystem).OSArchitecture
64 ビット

On the other hand, I check Windows 7 64bit English and Windows 7 64bit arabic.
They return a value as "64-bit".

But I don't know what value the other languages return, so I modify it to check only '64'.
It's not a good modification. I hope someone improves it.
