### PR TITLE
Avoiding commentout in crontab

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -190,9 +190,9 @@ module SpecInfra
       def check_cron_entry(user, entry)
         entry_escaped = entry.gsub(/\*/, '\\*')
         if user.nil?
-          "crontab -l | grep -- #{escape(entry_escaped)}"
+          "crontab -l | grep -v \"#\" -- | grep -- #{escape(entry_escaped)}"
         else
-          "crontab -u #{escape(user)} -l | grep -- #{escape(entry_escaped)}"
+          "crontab -u #{escape(user)} -l | grep -v \"#\" | grep -- #{escape(entry_escaped)}"
         end
       end
 


### PR DESCRIPTION
Many of engineers comment out the lines in crontab when they doesn't use the cron temporary. I think serverspec shouldn't return success when crontab have the comment outed line. 
For example,

> $ crontab -l
> # 30 \* \* \* \* /usr/local/script/test.sh
> 
> describe cron do
>  it { should have_entry '30 \* \* \* \* /usr/local/script/test.sh'}
> end

I think the above example should return fail. I modified it in this pull request.
