### PR TITLE
Fix for Pull Request #93 grep in extended regular expression mode

### DIFF
--- a/lib/specinfra/command/debian.rb
+++ b/lib/specinfra/command/debian.rb
@@ -11,7 +11,7 @@ module SpecInfra
         if version
           cmd = "dpkg-query -f '${Status} ${Version}' -W #{escaped_package} | grep -E '^(install|hold) ok installed #{escape(version)}$'"
         else
-          cmd = "dpkg-query -f '${Status}' -W #{escaped_package} | grep '^(install|hold) ok installed$'"
+          cmd = "dpkg-query -f '${Status}' -W #{escaped_package} | grep -E '^(install|hold) ok installed$'"
         end
         cmd
       end


### PR DESCRIPTION
Use grep in extended regular expression mode. Without the -E the pattern needs to be escaped.
