### PR TITLE
support get_package_version for smartos

### DIFF
--- a/lib/specinfra/command/smartos.rb
+++ b/lib/specinfra/command/smartos.rb
@@ -18,7 +18,7 @@ module SpecInfra
       end
 
       def get_package_version(package, opts=nil)
-        "pkgin list | cut -f 1 -d ' ' | grep -E '^#{package}-([^-])+$' | grep -Eo '(\\.|\\w)+$'"
+        "pkgin list | cut -f 1 -d ' ' | grep -E '^#{escape(package)}-([^-])+$' | grep -Eo '(\\.|\\w)+$'"
       end
     end
   end


### PR DESCRIPTION
Hi,

I write `#get_package_version` for joyent smartos.
## Case success

```
> backend.check_os
=> {:family=>"SmartOS", :release=>nil}

> backend.get_package_version('openssl')
=> #<SpecInfra::CommandResult:0x007fb82e1b8be8
 @exit_signal=nil,
 @exit_status=0,
 @stderr="",
 @stdout="openssl-1.0.1fnb1\n">
```
## Case fail

```
> backend.get_package_version('openss')
=> #<SpecInfra::CommandResult:0x007fb82e309588
 @exit_signal=nil,
 @exit_status=1,
 @stderr="",
 @stdout="">
```
