### PR TITLE
Add OpenBSD specific commands for checking file status

### DIFF
--- a/lib/specinfra/command/openbsd.rb
+++ b/lib/specinfra/command/openbsd.rb
@@ -47,9 +47,23 @@ module SpecInfra
         "egrep '^#{escape(recipient)}:.*#{escape(target)}' /etc/mail/aliases"
       end
 
+      def check_link(link, target)
+        "stat -f %Y #{escape(link)} | grep -- #{escape(target)}"
+      end
+
       def check_mode(file, mode)
         regexp = "^#{mode}$"
         "stat -f%Lp #{escape(file)} | grep #{escape(regexp)}"
+      end
+
+      def check_owner(file, owner)
+        regexp = "^#{owner}$"
+        "stat -f %Su #{escape(file)} | grep -- #{escape(regexp)}"
+      end
+
+      def check_grouped(file, group)
+        regexp = "^#{group}$"
+        "stat -f %Sg #{escape(file)} | grep -- #{escape(regexp)}"
       end
 
       def check_mounted(path)


### PR DESCRIPTION
In lib/specinfra/command/base.rb, some file status checking commands are implemented with `stat -c <format>`.
However, `stat` command in OpenBSD provides `-f` option rather than `-c` option to specify output format.
This PR adds OpenBSD specific file status checking commands implemented with `stat -f <format>`.
