### PR TITLE
Fix to get matched all processes on Command::Base#get_process

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -122,7 +122,7 @@ module SpecInfra
       end
 
       def get_process(process, opts)
-        "ps -C #{escape(process)} -o #{opts[:format]} | head -1"
+        "ps -C #{escape(process)} -o #{opts[:format]}"
       end
 
       def check_file_contain(file, expected_pattern)


### PR DESCRIPTION
When some processes were running with same command name but has different arguments, such as

```
$ pgrep java -lf
25817 java Main
25844 java Hoge
25856 java Fuga
```

I tried to execute `spec/localhost/java_spec.rb` but its failed.
Because `Command::Base#get_process` gets only 1 process using `| head -1` .

```
$ cat spec/localhost/java_spec.rb
require 'spec_helper'

describe process('java') do
  it { should be_running }
  its(:args) { should match /Main/ }
  its(:args) { should match /Hoge/ }
  its(:args) { should match /Fuga/ }
end

$ rake spec
/usr/bin/ruby1.9 -S rspec spec/localhost/java_spec.rb
..FF

Failures:

  1) Process "java" args should match /Hoge/
     Failure/Error: its(:args) { should match /Hoge/ }
       ps -C java -o args= | head -1
       java Main
       expected "java Main" to match /Hoge/
       Diff:
       @@ -1,2 +1,2 @@
       -/Hoge/
       +"java Main"
     # ./spec/localhost/java_spec.rb:6:in `block (2 levels) in <top (required)>'

  2) Process "java" args should match /Fuga/
     Failure/Error: its(:args) { should match /Fuga/ }
       ps -C java -o args= | head -1
       java Main
       expected "java Main" to match /Fuga/
       Diff:
       @@ -1,2 +1,2 @@
       -/Fuga/
       +"java Main"
     # ./spec/localhost/java_spec.rb:7:in `block (2 levels) in <top (required)>'

Finished in 0.09278 seconds
4 examples, 2 failures

Failed examples:

rspec ./spec/localhost/java_spec.rb:6 # Process "java" args should match /Hoge/
rspec ./spec/localhost/java_spec.rb:7 # Process "java" args should match /Fuga/
/usr/bin/ruby1.9 -S rspec spec/localhost/java_spec.rb failed
```

This problem should be solved by my commit however there may be better solution.
Could you give me your comment?
