### PR TITLE
Add helper method `os` to get OS info easily

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -232,8 +232,8 @@ module SpecInfra
           { :family => 'Plamo', :release => nil }
         elsif run_command('uname -s').stdout =~ /AIX/i
           { :family => 'AIX', :release => nil }
-        elsif (os = run_command('uname -sr').stdout) && os =~ /SunOS/i
-          if os =~ /5.10/
+        elsif ( uname = run_command('uname -sr').stdout) && uname =~ /SunOS/i
+          if uname =~ /5.10/
             { :family => 'Solaris10', :release => nil }
           elsif run_command('grep -q "Oracle Solaris 11" /etc/release').success?
             { :family => 'Solaris11', :release => nil }
@@ -244,8 +244,8 @@ module SpecInfra
           end
         elsif run_command('uname -s').stdout =~ /Darwin/i
           { :family => 'Darwin', :release => nil }
-        elsif (os = run_command('uname -sr').stdout) && os =~ /FreeBSD/i
-          if os =~ /10./
+        elsif ( uname = run_command('uname -sr').stdout ) && uname =~ /FreeBSD/i
+          if uname =~ /10./
             { :family => 'FreeBSD10', :release => nil }
           else
             { :family => 'FreeBSD', :release => nil }

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -19,6 +19,15 @@ module SpecInfra
         VALID_OPTIONS_KEYS.inject({}) { |o, k| o.merge!(k => send(k)) }
       end
 
+      # Define os method explicitly to avoid stack level
+      # too deep caused by Helpet::DetectOS#os
+      def os
+        if @os.nil? && defined?(RSpec) && RSpec.configuration.respond_to?(:os)
+          @os = RSpec.configuration.os
+        end
+        @os
+      end
+
       def method_missing(meth, val=nil)
         key = meth.to_s
         key.gsub!(/=$/, '')

--- a/lib/specinfra/helper/detect_os.rb
+++ b/lib/specinfra/helper/detect_os.rb
@@ -2,17 +2,24 @@ module SpecInfra
   module Helper
     module DetectOS
       def commands
+        self.class.const_get('SpecInfra').const_get('Command').const_get(os[:family]).new
+      end
+
+      def os
         property[:os_by_host] = {} if ! property[:os_by_host]
         host = SpecInfra.configuration.ssh ? SpecInfra.configuration.ssh.host : 'localhost'
 
         if property[:os_by_host][host]
-          os = property[:os_by_host][host]
+          os_by_host = property[:os_by_host][host]
         else
           # Set command object explicitly to avoid `stack too deep`
-          os = backend(SpecInfra::Command::Base.new).check_os
-          property[:os_by_host][host] = os
+          raise "crash me" if caller.length > 500
+          os_by_host = backend(SpecInfra::Command::Base.new).check_os
+
+          property[:os_by_host][host] = os_by_host
         end
-        self.class.const_get('SpecInfra').const_get('Command').const_get(os[:family]).new
+
+        os_by_host
       end
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -7,3 +7,8 @@ end
 describe RSpec.configuration.path do
   it { should eq SpecInfra.configuration.path }
 end
+
+SpecInfra.configuration.os = 'foo'
+describe SpecInfra.configuration.os do
+  it { should eq 'foo' }
+end


### PR DESCRIPTION
With this helper method, you can write OS specific code like this.

``` ruby
if ['rhel', 'centos'].include?(os[:family])
  # rhel related environment spec
  if os[:arch] == 'i386'
    # 32bit environment spec
  else
  end
elsif ['debian', 'ubuntu'].include?(os[:family])
  # debian related environment spec
end
```

Another example with serverspec.

``` ruby
describe file('/usr/lib64'), if: os[:arch] == 'x86_64' do
  # ...
end
```

See #110 also.
