### PR TITLE
check_os() returns CPU architecture

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -181,6 +181,7 @@ module SpecInfra
 
       def check_os
         return SpecInfra.configuration.os if SpecInfra.configuration.os
+        arch = run_command('uname -m').stdout.strip
         # Fedora also has an /etc/redhat-release so the Fedora check must
         # come before the RedHat check
         if run_command('ls /etc/fedora-release').success?
@@ -194,19 +195,20 @@ module SpecInfra
           if line =~ /release (\d[\d.]*)/
             release = $1
           end
+
           if release =~ /7./
-            { :family => 'RedHat7', :release => release }
+            { :family => 'RedHat7', :release => release, :arch => arch }
           else
-            { :family => 'RedHat', :release => release }
+            { :family => 'RedHat', :release => release, :arch => arch }
           end
         elsif run_command('ls /etc/system-release').success?
-          { :family => 'RedHat', :release => nil } # Amazon Linux
+          { :family => 'RedHat', :release => nil, :arch => arch } # Amazon Linux
         elsif run_command('ls /etc/SuSE-release').success?
           line = run_command('cat /etc/SuSE-release').stdout
           if line =~ /SUSE Linux Enterprise Server (\d+)/
             release = $1
           end
-          { :family => 'SuSE', :release => release }
+          { :family => 'SuSE', :release => release, :arch => arch }
         elsif run_command('ls /etc/debian_version').success?
           lsb_release = run_command("lsb_release -ir")
           if lsb_release.success?
@@ -225,37 +227,37 @@ module SpecInfra
           end
           distro ||= 'Debian'
           release ||= nil
-          { :family => distro.strip, :release => release }
+          { :family => distro.strip, :release => release, :arch => arch }
         elsif run_command('ls /etc/gentoo-release').success?
-          { :family => 'Gentoo', :release => nil }
+          { :family => 'Gentoo', :release => nil, :arch => arch }
         elsif run_command('ls /usr/lib/setup/Plamo-*').success?
-          { :family => 'Plamo', :release => nil }
+          { :family => 'Plamo', :release => nil, :arch => arch }
         elsif run_command('uname -s').stdout =~ /AIX/i
-          { :family => 'AIX', :release => nil }
+          { :family => 'AIX', :release => nil, :arch => arch }
         elsif ( uname = run_command('uname -sr').stdout) && uname =~ /SunOS/i
           if uname =~ /5.10/
-            { :family => 'Solaris10', :release => nil }
+            { :family => 'Solaris10', :release => nil, :arch => arch }
           elsif run_command('grep -q "Oracle Solaris 11" /etc/release').success?
-            { :family => 'Solaris11', :release => nil }
+            { :family => 'Solaris11', :release => nil, :arch => arch }
           elsif run_command('grep -q SmartOS /etc/release').success?
-            { :family => 'SmartOS', :release => nil }
+            { :family => 'SmartOS', :release => nil, :arch => arch }
           else
-            { :family => 'Solaris', :release => nil }
+            { :family => 'Solaris', :release => nil, :arch => arch }
           end
         elsif run_command('uname -s').stdout =~ /Darwin/i
           { :family => 'Darwin', :release => nil }
         elsif ( uname = run_command('uname -sr').stdout ) && uname =~ /FreeBSD/i
           if uname =~ /10./
-            { :family => 'FreeBSD10', :release => nil }
+            { :family => 'FreeBSD10', :release => nil, :arch => arch }
           else
-            { :family => 'FreeBSD', :release => nil }
+            { :family => 'FreeBSD', :release => nil, :arch => arch }
           end
         elsif run_command('uname -sr').stdout =~ /Arch/i
-          { :family => 'Arch', :release => nil }
+          { :family => 'Arch', :release => nil, :arch => arch }
         elsif run_command('uname -s').stdout =~ /OpenBSD/i
-          { :family => 'OpenBSD', :release => nil }
+          { :family => 'OpenBSD', :release => nil, :arch => arch }
         else
-          { :family => 'Base', :release => nil }
+          { :family => 'Base', :release => nil, :arch => arch }
         end
       end
 

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -35,56 +35,61 @@ describe 'check_os' do
   context 'test ubuntu with lsb_release command' do
     subject { backend.check_os }
     it do
-      mock_success_response = double(
-        :run_command_response,
-        :success? => true,
-        :stdout => "Distributor ID:\tUbuntu\nRelease:\t12.04\n"
-      )
-      mock_failure_response = double :run_command_response, :success? => false
       backend.should_receive(:run_command).at_least(1).times do |args|
         if ['ls /etc/debian_version', 'lsb_release -ir'].include? args
-          mock_success_response
+          double(
+            :run_command_response,
+            :success? => true,
+            :stdout => "Distributor ID:\tUbuntu\nRelease:\t12.04\n"
+          )
+        elsif args == 'uname -m'
+          double :run_command_response, :success? => true, :stdout => "x86_64\n"
         else
-          mock_failure_response
+          double :run_command_response, :success? => false
         end
       end
-      should eq({:family => 'Ubuntu', :release => '12.04'})
+      should eq({:family => 'Ubuntu', :release => '12.04', :arch => 'x86_64' })
     end
   end
 
   context 'test ubuntu with /etc/lsb-release' do
     subject { backend.check_os }
     it do
-      mock_success_response = double(
-        :run_command_response,
-        :success? => true,
-        :stdout => %Q(DISTRIB_ID=Ubuntu
+      backend.should_receive(:run_command).at_least(1).times do |args|
+        if ['ls /etc/debian_version', 'cat /etc/lsb-release'].include? args
+          double(
+            :run_command_response,
+            :success? => true,
+            :stdout => <<-EOF
+DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=12.04
 DISTRIB_CODENAME=precise
 DISTRIB_DESCRIPTION="Ubuntu 12.04.2 LTS"
-)
-      )
-      mock_failure_response = double :run_command_response, :success? => false
-      backend.should_receive(:run_command).at_least(1).times do |args|
-        if ['ls /etc/debian_version', 'cat /etc/lsb-release'].include? args
-          mock_success_response
+EOF
+          )
+        elsif args == 'uname -m'
+          double :run_command_response, :success? => true, :stdout => "x86_64\n"
         else
-          mock_failure_response
+          double :run_command_response, :success? => false
         end
       end
-      should eq({:family => 'Ubuntu', :release => '12.04'})
+      should eq({:family => 'Ubuntu', :release => '12.04', :arch => 'x86_64' })
     end
   end
 
   context 'test debian (no lsb_release or lsb-release)' do
     subject { backend.check_os }
     it do
-      mock_success_response = double :run_command_response, :success? => true
-      mock_failure_response = double :run_command_response, :success? => false
       backend.should_receive(:run_command).at_least(1).times do |args|
-        args == 'ls /etc/debian_version' ? mock_success_response : mock_failure_response
+        if args == 'ls /etc/debian_version'
+          double :run_command_response, :success? => true
+        elsif args == 'uname -m'
+          double :run_command_response, :success? => true, :stdout => "x86_64\n"
+        else
+          double :run_command_response, :success? => false
+        end
       end
-      should eq({:family => 'Debian', :release => nil})
+      should eq({:family => 'Debian', :release => nil, :arch => 'x86_64' })
     end
   end
 end


### PR DESCRIPTION
Now you can get CPU architechture with `os[:arch]`.

See also #110 .
