### PR TITLE
Add Specinfra::Runner to avoid calling the helper method `backend` outside Specinfra

### DIFF
--- a/lib/specinfra.rb
+++ b/lib/specinfra.rb
@@ -1,9 +1,10 @@
-require "specinfra/version"
-require "specinfra/helper"
-require "specinfra/backend"
-require "specinfra/command"
-require "specinfra/command_result"
-require "specinfra/configuration"
+require 'specinfra/version'
+require 'specinfra/helper'
+require 'specinfra/backend'
+require 'specinfra/command'
+require 'specinfra/command_result'
+require 'specinfra/configuration'
+require 'specinfra/runner'
 
 include Specinfra
 

--- a/lib/specinfra/runner.rb
+++ b/lib/specinfra/runner.rb
@@ -1,0 +1,8 @@
+module Specinfra
+  class Runner
+    include Singleton
+    def method_missing(meth, *args, &block)
+      backend.send(meth, *args)
+    end
+  end
+end


### PR DESCRIPTION
It is difficult to following the part calling backend method in Serverspec.
So I' like to improve it.
