### PR TITLE
convert ppa:username/reponame to apt_line_uri

### DIFF
--- a/lib/specinfra/command/ubuntu.rb
+++ b/lib/specinfra/command/ubuntu.rb
@@ -6,19 +6,17 @@ module SpecInfra
       end
 
       def check_ppa(package)
-        repo_name = to_apt_line_uri(package)
-        "find /etc/apt/ -name \*.list | xargs grep -o \"deb http://ppa.launchpad.net/#{escape(repo_name)}\""
+        %Q{find /etc/apt/ -name \*.list | xargs grep -o "deb http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
       end
 
       def check_ppa_enabled(package)
-        repo_name = to_apt_line_uri(package)
-        "find /etc/apt/ -name \*.list | xargs grep -o \"^deb http://ppa.launchpad.net/#{escape(repo_name)}\""
+        %Q{find /etc/apt/ -name \*.list | xargs grep -o "^deb http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
       end
 
       private
 
       def to_apt_line_uri(repo)
-        repo.gsub(/^ppa:/,'')
+        escape(repo.gsub(/^ppa:/,''))
       end
     end
   end


### PR DESCRIPTION
I think more convienient if ppa resource type accepts `ppa:launchpad-username/reponame` style.

Usually, PPA is denoted `ppa:launchpad-username/ppa-repository-name` style.

This PR makes that ppa resource type accepts both `ppa:username/reponame` and `username/reponame` style.
