### PR TITLE
fix square brackets error in cron resource type

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -200,7 +200,7 @@ module SpecInfra
       end
 
       def check_cron_entry(user, entry)
-        entry_escaped = entry.gsub(/\*/, '\\*')
+        entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]')
         if user.nil?
           "crontab -l | grep -v \"#\" -- | grep -- #{escape(entry_escaped)}"
         else

--- a/lib/specinfra/command/solaris.rb
+++ b/lib/specinfra/command/solaris.rb
@@ -28,7 +28,7 @@ module SpecInfra
       end
 
       def check_cron_entry(user, entry)
-        entry_escaped = entry.gsub(/\*/, '\\*')
+        entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]')
         if user.nil?
           "crontab -l | grep -- #{escape(entry_escaped)}"
         else


### PR DESCRIPTION
This patch is to fix square brackets error in cron resource type.

```
Failures:

  1) Cron should have entry "* * * * * [ -x /tmp/test.txt ] && /root/test.sh"
     Failure/Error: it { should have_entry('* * * * * [ -x /tmp/test.txt ] && /root/test.sh').with_user('root') }
       sudo crontab -u root -l | grep -v "#" | grep -- \\\*\ \\\*\ \\\*\ \\\*\ \\\*\ \[\ -x\ /tmp/test.txt\ \]\ \&\&\ /root/test.sh
       expected Cron "" to have entry "* * * * * [ -x /tmp/test.txt ] && /root/test.sh"
     # ./spec/node/cron_spec.rb:4:in `block (2 levels) in <top (required)>'

Finished in 4.79 seconds
2 examples, 1 failure

Failed examples:

rspec ./spec/node/cron_spec.rb:4 # Cron should have entry "* * * * * [ -x /tmp/test.txt ] && /root/test.sh"

```
