### PR TITLE
Cache os based on host and port

### DIFF
--- a/lib/specinfra/command/fedora.rb
+++ b/lib/specinfra/command/fedora.rb
@@ -2,8 +2,8 @@ module SpecInfra
   module Command
     class Fedora < RedHat
       def check_enabled(service, target="multi-user.target")
-        host = SpecInfra.configuration.ssh ? SpecInfra.configuration.ssh.host : 'localhost'
-        if property.has_key?(:os_by_host) && property[:os_by_host][host][:release].to_i < 15
+        host_port = SpecInfra.configuration.ssh ? [SpecInfra.configuration.ssh.host, SpecInfra.configuration.ssh.options[:port]] : ['localhost', nil]
+        if property.has_key?(:os_by_host) && property[:os_by_host][host_port][:release].to_i < 15
           super
         else
           # Fedora 15+ uses systemd which no longer has runlevels but targets
@@ -17,8 +17,8 @@ module SpecInfra
       end
 
       def check_running(service)
-        host = SpecInfra.configuration.ssh ? SpecInfra.configuration.ssh.host : 'localhost'
-        if property.has_key?(:os_by_host) && property[:os_by_host][host][:release].to_i < 15
+        host_port = SpecInfra.configuration.ssh ? [SpecInfra.configuration.ssh.host, SpecInfra.configuration.ssh.options[:port]] : ['localhost', nil]
+        if property.has_key?(:os_by_host) && property[:os_by_host][host_port][:release].to_i < 15
           super
         else
           "systemctl is-active #{escape(service)}.service"

--- a/lib/specinfra/helper/detect_os.rb
+++ b/lib/specinfra/helper/detect_os.rb
@@ -7,17 +7,28 @@ module SpecInfra
 
       def os
         property[:os_by_host] = {} if ! property[:os_by_host]
-        host = SpecInfra.configuration.ssh ? SpecInfra.configuration.ssh.host : 'localhost'
+        host_port = current_host_and_port
 
-        if property[:os_by_host][host]
-          os_by_host = property[:os_by_host][host]
+        if property[:os_by_host][host_port]
+          os_by_host = property[:os_by_host][host_port]
         else
           # Set command object explicitly to avoid `stack too deep`
           os_by_host = backend(SpecInfra::Command::Base.new).check_os
-          property[:os_by_host][host] = os_by_host
+          property[:os_by_host][host_port] = os_by_host
         end
 
         os_by_host
+      end
+
+      private
+
+      # put this in a module for better reuse
+      def current_host_and_port
+        if SpecInfra.configuration.ssh
+          [SpecInfra.configuration.ssh.host, SpecInfra.configuration.ssh.options[:port]]
+        else
+          ['localhost', nil]
+        end
       end
     end
   end


### PR DESCRIPTION
At the moment the DetectOS module caches the detected os data based on ssh.host configuration, i.e. if the current ssh connection is to the same host then specinfra keeps using the same os. I found myself using vagrant with multiple vm running at the same time, and with different operating systems (e.g. redhat and ubuntu). Vagrant allows you to specify different ssh ports to use when connecting to its running instances.

With this change the DetectOS module also considers the port number of the ssh connection in order to retrieve the cached os, i.e. it uniquely identifies a server using both the hostname and the port number used for the ssh connection. This allows me to run multiple specs at the same time against different vagrant machines (with different os) running on my host 
