### PR TITLE
Fix check_container_running to work with any versions of LXC

### DIFF
--- a/lib/specinfra/command/linux.rb
+++ b/lib/specinfra/command/linux.rb
@@ -63,7 +63,7 @@ module SpecInfra
       end
 
       def check_container_running(container)
-        "lxc-info -n #{escape(container)} -t RUNNING"
+        "lxc-info -n #{escape(container)} -s | grep -w RUNNING"
       end
 
       def check_attribute(file, attribute)


### PR DESCRIPTION
The original 'check_container_running' can only work with lxc 0.9.0,
but now can work with any versions.
