### PR TITLE
Specify all paths including $PATH

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -52,7 +52,7 @@ module Specinfra
 
         path = Specinfra.configuration.path
         if path
-          cmd = "env PATH=#{path.shellescape}:\"$PATH\" #{cmd}"
+          cmd = %Q{env PATH="#{path}" #{cmd}}
         end
 
         cmd

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -46,7 +46,7 @@ describe Specinfra::Backend::Exec do
 
     context 'with custom path' do
       before do
-        RSpec.configure {|c| c.path = '/opt/bin:/opt/foo/bin' }
+        RSpec.configure {|c| c.path = '/opt/bin:/opt/foo/bin:$PATH' }
       end
 
       after do
@@ -54,13 +54,13 @@ describe Specinfra::Backend::Exec do
       end
 
       it 'should use custom path' do
-        expect(backend.build_command('test -f /etc/passwd')).to eq 'env PATH=/opt/bin:/opt/foo/bin:"$PATH" /bin/sh -c test\ -f\ /etc/passwd'
+        expect(backend.build_command('test -f /etc/passwd')).to eq 'env PATH="/opt/bin:/opt/foo/bin:$PATH" /bin/sh -c test\ -f\ /etc/passwd'
       end
     end
 
     context 'with custom path that needs escaping' do
       before do
-        RSpec.configure {|c| c.path = '/opt/bin:/opt/test & spec/bin' }
+        RSpec.configure {|c| c.path = '/opt/bin:/opt/test & spec/bin:$PATH' }
       end
 
       after do
@@ -68,7 +68,7 @@ describe Specinfra::Backend::Exec do
       end
 
       it 'should use custom path' do
-        expect(backend.build_command('test -f /etc/passwd')).to eq 'env PATH=/opt/bin:/opt/test\ \&\ spec/bin:"$PATH" /bin/sh -c test\ -f\ /etc/passwd'
+        expect(backend.build_command('test -f /etc/passwd')).to eq 'env PATH="/opt/bin:/opt/test & spec/bin:$PATH" /bin/sh -c test\ -f\ /etc/passwd'
       end
     end
   end


### PR DESCRIPTION
In specinfra 1.x, path is added in front of $PATH automatically.

In 2.0, you must include $PATH like this.

``` ruby
set :path, '/sbin:/usr/local/sbin:$PATH'
```
