### PR TITLE
Move check_running function to use 'service' command

### DIFF
--- a/lib/specinfra/command/opensuse.rb
+++ b/lib/specinfra/command/opensuse.rb
@@ -6,7 +6,7 @@ module SpecInfra
       end
 
       def check_running(service)
-        "systemctl is-active #{escape(service)}.service"
+        "service #{escape(service)} status"
       end
 
     end


### PR DESCRIPTION
When using an old init script instead of systemd files
the current 'systemctl is-active' call fails for any init based services
The 'service' command will redirect to systemctl if it can't find the correct init file

the check_enabled part with systemctl does redirect:

```
# systemctl is-enabled logstash.service
logstash.service is not a native service, redirecting to /sbin/chkconfig.
Executing /sbin/chkconfig logstash --level=5
logstash  on
enabled
```

The is-active part does not:

```
# systemctl is-active logstash.service
inactive
```

```
# service logstash status
logstash is running
```

When using the 'service $service status' call it does redirect to systemctl if there is no init script:

```
# systemctl is-active  ntp.service
active
```

```
# service ntp status
redirecting to systemctl
ntp.service - LSB: Network time protocol daemon (ntpd)
          Loaded: loaded (/etc/init.d/ntp)
          Active: active (running) since Sun, 03 Aug 2014 07:10:04 -0500; 37min ago
         Process: 3318 ExecStart=/etc/init.d/ntp start (code=exited, status=0/SUCCESS)
          CGroup: name=systemd:/system/ntp.service
                  └ 3346 /usr/sbin/ntpd -p /var/run/ntp/ntpd.pid -g -u ntp:ntp -i /var/lib/ntp -c /etc/ntp.conf
```
