### PR TITLE
Add pkgutil support for OS X package install checks

### DIFF
--- a/lib/specinfra/command/darwin.rb
+++ b/lib/specinfra/command/darwin.rb
@@ -58,6 +58,12 @@ module SpecInfra
         end
         cmd
       end
+      alias :check_installed_by_homebrew :check_installed
+
+      def check_installed_by_pkgutil(package, version=nil)
+        cmd = "pkgutil --pkg-info #{package}"
+        cmd = "#{cmd} | grep '^version: #{escape(version)}'" if version
+      end
 
       def install(package)
         cmd = "brew install '#{package}'"


### PR DESCRIPTION
I've got a .dmg file package being installed with the OS X's system packager and want to be able to test its status with `pkgutil`. This adds support for that.

For example, command line:

```
$ pkgutil --pkg-info com.getchef.pkg.chefdk
package-id: com.getchef.pkg.chefdk
version: 0.2.0
volume: /
location: opt/chefdk
install-time: 1406598641
```

is now testable from ServerSpec with:

```
expect(package('com.getchef.pkg.chefdk')).to be_installed.by(:pkgutil).with_version('0.2.0')
```
