### PR TITLE
Rename Command::Processor to Processor

### DIFF
--- a/lib/specinfra.rb
+++ b/lib/specinfra.rb
@@ -5,6 +5,7 @@ require 'specinfra/command'
 require 'specinfra/command_result'
 require 'specinfra/configuration'
 require 'specinfra/runner'
+require 'specinfra/processor'
 
 include Specinfra
 

--- a/lib/specinfra/backend/base.rb
+++ b/lib/specinfra/backend/base.rb
@@ -1,6 +1,5 @@
 require 'singleton'
 require 'specinfra/command_result'
-require 'specinfra/command/processor'
 
 module Specinfra
   module Backend

--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -1,4 +1,4 @@
-module Specinfra::Command
+module Specinfra
   class Processor
     def self.method_missing(meth, *args, &block)
       Specinfra.backend.send(meth, *args)

--- a/lib/specinfra/runner.rb
+++ b/lib/specinfra/runner.rb
@@ -4,7 +4,7 @@ module Specinfra
       if os.include?(:family) && os[:family] == 'windows'
         Specinfra.backend.send(meth, *args)
       else
-        Specinfra::Command::Processor.send(meth, *args)
+        Specinfra::Processor.send(meth, *args)
       end
     end
   end


### PR DESCRIPTION
Because it's irrelevant to other command classes directly
