### PR TITLE
var interpolation in item_has_attribute

### DIFF
--- a/lib/specinfra/command/windows.rb
+++ b/lib/specinfra/command/windows.rb
@@ -385,7 +385,7 @@ module SpecInfra
       private
 
       def item_has_attribute item, attribute
-        "((Get-Item -Path \"#{item}\" -Force).attributes.ToString() -Split ', ') -contains '#{attribute}'"
+        %Q!((Get-Item -Path "#{item}" -Force).attributes.ToString() -Split ', ') -contains '#{attribute}'!
       end
 
       def convert_key_property_value property


### PR DESCRIPTION
Added double quotes around #{item} in  item_has_attribute to allow for variable interpolation. This is related to issue serverspec/serverspec#451
