### PR TITLE
Make grep silent about non-existing files

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -142,11 +142,11 @@ module SpecInfra
       end
 
       def check_file_contain_with_regexp(file, expected_pattern)
-        "grep -q -- #{escape(expected_pattern)} #{escape(file)}"
+        "grep -qs -- #{escape(expected_pattern)} #{escape(file)}"
       end
 
       def check_file_contain_with_fixed_strings(file, expected_pattern)
-        "grep -qF -- #{escape(expected_pattern)} #{escape(file)}"
+        "grep -qFs -- #{escape(expected_pattern)} #{escape(file)}"
       end
 
       def check_file_checksum(file, expected)


### PR DESCRIPTION
Currently, when checking for the content of a file using
serverspec, grep complains about non-existing files. This adds
the -s (--silent) option to the grep command to address this.
