### PR TITLE
Added more strict check on `check_file_contain_within`

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -168,9 +168,10 @@ module SpecInfra
         from ||= '1'
         to ||= '$'
         sed = "sed -n #{escape(from)},#{escape(to)}p #{escape(file)}"
+        sed_end = "sed -n 1,#{escape(to)}p"
         checker_with_regexp = check_file_contain_with_regexp("-", expected_pattern)
         checker_with_fixed  = check_file_contain_with_fixed_strings("-", expected_pattern)
-        "#{sed} | #{checker_with_regexp} || #{sed} | #{checker_with_fixed}"
+        "#{sed} | #{sed_end} | #{checker_with_regexp} || #{sed} | #{sed_end} | #{checker_with_fixed}"
       end
 
       def check_file_contain_lines(file, expected_lines, from=nil, to=nil)

--- a/lib/specinfra/command/solaris.rb
+++ b/lib/specinfra/command/solaris.rb
@@ -76,9 +76,10 @@ module SpecInfra
         from ||= '1'
         to ||= '$'
         sed = "sed -n #{escape(from)},#{escape(to)}p #{escape(file)}"
+        sed_end = "sed -n 1,#{escape(to)}p"
         checker_with_regexp = check_file_contain_with_regexp("/dev/stdin", expected_pattern)
         checker_with_fixed  = check_file_contain_with_fixed_strings("/dev/stdin", expected_pattern)
-        "#{sed} | #{checker_with_regexp} || #{sed} | #{checker_with_fixed}"
+        "#{sed} | #{sed_end} | #{checker_with_regexp}|| #{sed} | #{sed_end} | #{checker_with_fixed}"
       end
 
       def check_belonging_group(user, group)


### PR DESCRIPTION
I believe I have a solution that will address [this issue](https://github.com/serverspec/serverspec/issues/467), but I need some help with the tests. Right out of the gates I noticed the `integration-tests` submodule but I couldn't get `rake spec` to work. Is there any special set up that I need to do to get that working? I went ahead and submitted what I think is a good solution, but I would still like to add some tests to verify and ensure that there are no regressions due to this change.

`check_file_contain_within` uses `sed`'s range, however when the end
portion of the range is not found in the file the end of the file will
be the end of the range. This can cause false positives when an end is
missing.

For example:

```
<IfModule>
<IfModule>
StartServers 5
```

would currently pass the following assertion in [serverspec](https://github.com/serverspec/)

```
it { should contain('StartServers 5').from(/^<IfModule>/).to(/^<\/IfModule>/) }
```

I would expect this to fail due to the fact that `</IfModule>` does not
exist in the example above.

The solution that I propose is adding an additional check that will
verify the range using `sed` as it currently does plus doing the
equivalent of what the `contain().before()` does on the closing tag.
