### PR TITLE
This fixes a regression with `check_file_contain_within`

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -168,10 +168,10 @@ module SpecInfra
         from ||= '1'
         to ||= '$'
         sed = "sed -n #{escape(from)},#{escape(to)}p #{escape(file)}"
-        sed_end = "sed -n 1,#{escape(to)}p"
+        sed += " | sed -n 1,#{escape(to)}p" if from != '1' and to != '$'
         checker_with_regexp = check_file_contain_with_regexp("-", expected_pattern)
         checker_with_fixed  = check_file_contain_with_fixed_strings("-", expected_pattern)
-        "#{sed} | #{sed_end} | #{checker_with_regexp} || #{sed} | #{sed_end} | #{checker_with_fixed}"
+        "#{sed} | #{checker_with_regexp} || #{sed} | #{checker_with_fixed}"
       end
 
       def check_file_contain_lines(file, expected_lines, from=nil, to=nil)


### PR DESCRIPTION
A apologize in advance for not providing any tests with this PR, I took another stab at it but I was getting vagrant errors: "Vagrant: \* Unknown configuration section 'omnibus'". I did write tests and verified that this works correctly - I actually used the tests in the serverspec repo and used `gem open` to make this change. (I can submit another PR for that repo that contains the updated tests).

With [this PR](https://github.com/serverspec/specinfra/pull/191) a
regression was introduced with the `before` and `after` matchers when
they aren't being used together.

With PR 191 the following:

```
  it { should contain('rspec').before(/^end/) }
```

would have resulted in:

```
  sed -n 1,/\\^end/p Gemfile | sed -n 1,/\\^end/p | grep -qs -- rspec - || sed -n 1,/\\^end/p Gemfile | sed -n 1,/\\^end/p | grep -qFs -- rspec -
```

as well as:

```
    it { should contain('rspec').after(/^group :test do/) }
```

would result in:

```
    sed -n /\\^group\\ :test\\ do/,\\$p Gemfile | sed -n 1,\\$p | grep -qs -- rspec - || sed -n /\\^group\\ :test\\ do/,\\$p Gemfile | sed -n 1,\\$p | grep -qFs -- rspec -
```

Notice in both scenarios the `sed` command is unnecessarily duplicated.

While neither of these should actually cause an assertion to pass when
it should fail, they also do not add anything for either situation.
