### PR TITLE
Fix mount check regexp

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -29,7 +29,7 @@ module SpecInfra
       end
 
       def check_mounted(path)
-        regexp = "on #{path}"
+        regexp = "on #{path} "
         "mount | grep -w -- #{escape(regexp)}"
       end
 


### PR DESCRIPTION
When we have the following entry in the `mount` output

```
tmpfs on /tmp/dir-1 type tmpfs (rw,seclabel)
```

`check_mounted('/tmp/dir')` falsely matches the above entry.
