### PR TITLE
Wildcard whitespace in repository regex

### DIFF
--- a/lib/specinfra/command/ubuntu/base/ppa.rb
+++ b/lib/specinfra/command/ubuntu/base/ppa.rb
@@ -1,11 +1,11 @@
 class Specinfra::Command::Ubuntu::Base::Ppa < Specinfra::Command::Debian::Base::Ppa
   class << self
     def check_exists(package)
-      %Q{find /etc/apt/ -name \*.list | xargs grep -o "deb http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
+      %Q{find /etc/apt/ -name \*.list | xargs grep -o "deb +http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
     end
 
     def check_is_enabled(package)
-      %Q{find /etc/apt/ -name \*.list | xargs grep -o "^deb http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
+      %Q{find /etc/apt/ -name \*.list | xargs grep -o "^deb +http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
     end
 
     private


### PR DESCRIPTION
The chef "apt" cookbook adds repositories with extra spaces. Since the size of the whitespace isn't important we need to wildcard it.
