### PR TITLE
Fixed no escaped space bug(53af9a6)

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -30,7 +30,7 @@ module SpecInfra
 
       def check_mounted(path)
         regexp = "on #{path} "
-        "mount | grep -w -- #{escape(regexp)}"
+        "mount | grep -- '#{escape(regexp)}'"
       end
 
       def check_routing_table(destination)


### PR DESCRIPTION
```
describe file("/home") do
    it { should be_mounted }
end
```

---

```
Failures:
1) マウント File "/home" should be mounted
     On host ``
     Failure/Error: it { should be_mounted }
       mount | grep -w -- on\ /home\
       expected File "/home" to be mounted
```

I have error above in the 53af9a6 commit.
I think grep command does not require the -w option. and need to escape the comma for regexp.
