### PR TITLE
Fix check_is_enabled for recent systemd

### DIFF
--- a/lib/specinfra/command/module/systemd.rb
+++ b/lib/specinfra/command/module/systemd.rb
@@ -4,7 +4,7 @@ module Specinfra::Command::Module::Systemd
       level = "runlevel#{level}.target"
     end
 
-    "systemctl --plain list-dependencies #{level} | grep '^#{escape(service)}.service$'"
+    "systemctl --plain list-dependencies #{level} | grep '\\(^\\| \\)#{escape(service)}.service$'"
   end
 
   def check_is_running(service)


### PR DESCRIPTION
Recent systemd outputs extra BLACK_CIRCLE mark on list-dependencies like below.

```
% systemctl list-dependencies --plain sysinit.target                                                                                                                                                                                                                                                  [~/git]
sysinit.target
* dev-hugepages.mount
* dev-mqueue.mount
* kmod-static-nodes.service
* ldconfig.service
...
```

Not that the mark may vary depending on the locale.
http://cgit.freedesktop.org/systemd/systemd/tree/src/shared/util.c?id=v215#n5468
