### PR TITLE
Support non-service systemd units

### DIFF
--- a/lib/specinfra/command/module/systemd.rb
+++ b/lib/specinfra/command/module/systemd.rb
@@ -3,35 +3,38 @@ module Specinfra::Command::Module::Systemd
     if level.to_s =~ /^\d+$/
       level = "runlevel#{level}.target"
     end
+    unless service.include?('.')
+      service += '.service'
+    end
 
-    "systemctl --plain list-dependencies #{level} | grep '\\(^\\| \\)#{escape(service)}.service$'"
+    "systemctl --plain list-dependencies #{level} | grep '\\(^\\| \\)#{escape(service)}$'"
   end
 
   def check_is_running(service)
-    "systemctl is-active #{escape(service)}.service"
+    "systemctl is-active #{escape(service)}"
   end
 
   def enable(service)
-    "systemctl enable #{escape(service)}.service"
+    "systemctl enable #{escape(service)}"
   end
 
   def disable(service)
-    "systemctl disable #{escape(service)}.service"
+    "systemctl disable #{escape(service)}"
   end
 
   def start(service)
-    "systemctl start #{escape(service)}.service"
+    "systemctl start #{escape(service)}"
   end
 
   def stop(service)
-    "systemctl stop #{escape(service)}.service"
+    "systemctl stop #{escape(service)}"
   end
 
   def restart(service)
-    "systemctl restart #{escape(service)}.service"
+    "systemctl restart #{escape(service)}"
   end
 
   def reload(service)
-    "systemctl reload #{escape(service)}.service"
+    "systemctl reload #{escape(service)}"
   end
 end

--- a/spec/command/module/systemd_spec.rb
+++ b/spec/command/module/systemd_spec.rb
@@ -2,10 +2,11 @@ require 'spec_helper'
 
 describe Specinfra::Command::Redhat::V7::Service do
   let(:klass) { Specinfra::Command::Redhat::V7::Service }
-  it { expect(klass.check_is_enabled('httpd')).to eq "systemctl --plain list-dependencies multi-user.target | grep '^httpd.service$'" }
-  it { expect(klass.check_is_enabled('httpd', 'multi-user.target')).to eq "systemctl --plain list-dependencies multi-user.target | grep '^httpd.service$'" }
-  it { expect(klass.check_is_enabled('httpd', 3)).to eq "systemctl --plain list-dependencies runlevel3.target | grep '^httpd.service$'" }
-  it { expect(klass.check_is_enabled('httpd', '3')).to eq "systemctl --plain list-dependencies runlevel3.target | grep '^httpd.service$'" }
+  it { expect(klass.check_is_enabled('httpd')).to eq "systemctl --plain list-dependencies multi-user.target | grep '\\(^\\| \\)httpd.service$'" }
+  it { expect(klass.check_is_enabled('httpd', 'multi-user.target')).to eq "systemctl --plain list-dependencies multi-user.target | grep '\\(^\\| \\)httpd.service$'" }
+  it { expect(klass.check_is_enabled('httpd', 3)).to eq "systemctl --plain list-dependencies runlevel3.target | grep '\\(^\\| \\)httpd.service$'" }
+  it { expect(klass.check_is_enabled('httpd', '3')).to eq "systemctl --plain list-dependencies runlevel3.target | grep '\\(^\\| \\)httpd.service$'" }
+  it { expect(klass.check_is_enabled('sshd.socket')).to eq "systemctl --plain list-dependencies multi-user.target | grep '\\(^\\| \\)sshd.socket$'" }
 end
 
 

--- a/spec/command/redhat7/service_spec.rb
+++ b/spec/command/redhat7/service_spec.rb
@@ -4,25 +4,29 @@ property[:os] = nil
 set :os, :family => 'redhat', :release => '7'
 
 describe get_command(:enable_service, 'httpd') do
-  it { should eq 'systemctl enable httpd.service' }
+  it { should eq 'systemctl enable httpd' }
 end
 
 describe get_command(:disable_service, 'httpd') do
-  it { should eq 'systemctl disable httpd.service' }
+  it { should eq 'systemctl disable httpd' }
 end
 
 describe get_command(:start_service, 'httpd') do
-  it { should eq 'systemctl start httpd.service' }
+  it { should eq 'systemctl start httpd' }
 end
 
 describe get_command(:stop_service, 'httpd') do
-  it { should eq 'systemctl stop httpd.service' }
+  it { should eq 'systemctl stop httpd' }
 end
 
 describe get_command(:restart_service, 'httpd') do
-  it { should eq 'systemctl restart httpd.service' }
+  it { should eq 'systemctl restart httpd' }
 end
 
 describe get_command(:reload_service, 'httpd') do
-  it { should eq 'systemctl reload httpd.service' }
+  it { should eq 'systemctl reload httpd' }
+end
+
+describe get_command(:enable_service, 'sshd.socket') do
+  it { should eq 'systemctl enable sshd.socket' }
 end


### PR DESCRIPTION
There's many unit types other than service.
And `systemctl start httpd` command is equivalent to
`systemctl start httpd.service`.
