### PR TITLE
Adds Linux support for check_ipv6_address

### DIFF
--- a/lib/specinfra/command/base.rb
+++ b/lib/specinfra/command/base.rb
@@ -332,6 +332,10 @@ module SpecInfra
       def check_ipv4_address(interface, ip_address)
         raise NotImplementedError.new
       end
+      
+      def check_ipv6_address(interface, ip_address)
+        raise NotImplementedError.new
+      end
 
       def check_mail_alias(recipient, target)
         target = "[[:space:]]#{target}"

--- a/lib/specinfra/command/linux.rb
+++ b/lib/specinfra/command/linux.rb
@@ -56,6 +56,17 @@ module SpecInfra
         ip_address.gsub!(".", "\\.")
         "ip addr show #{interface} | grep 'inet #{ip_address}'"
       end
+      
+      def check_ipv6_address(interface, ip_address)
+        ip_address = ip_address.dup
+        if ip_address =~ /\/\d+$/
+          ip_address << " "
+        else
+          ip_address << "/"
+        end
+        ip_address.downcase!
+        "ip addr show #{interface} | grep 'inet6 #{ip_address}'"
+      end
 
       def check_zfs(zfs, property=nil)
         if property.nil?


### PR DESCRIPTION
Adds support for check_ipv6_address (on Linux). It's 2014. specinfra should have_ipv6_support! :)
