### PR TITLE
use rcctl(8) when dealing with services on OpenBSD

### DIFF
--- a/lib/specinfra/command/openbsd.rb
+++ b/lib/specinfra/command/openbsd.rb
@@ -2,7 +2,7 @@ module SpecInfra
   module Command
     class OpenBSD < Base
       def check_enabled(service, level=3)
-        "egrep '(#{escape(service)}_flags=|^pkg_scripts=\"(.*)#{escape(service)}(.*)\")' /etc/rc.conf.local | grep -v \=NO"
+        "rcctl status #{escape(service)}"
       end
 
       def check_file_md5checksum(file, expected)
@@ -76,7 +76,7 @@ module SpecInfra
 #      end
 
       def check_running(service)
-        "/etc/rc.d/#{escape(service)} status"
+        "rcctl check #{escape(service)}"
       end
 
       def get_mode(file)


### PR DESCRIPTION
The format in which pkg_scripts are recorded has recently changed in OpenBSD, along with the introduction of a new tool called 'rcctl'. So use this to deal with services on OpenBSD instead of having to worry about the actual on disk format of the files.
