### PR TITLE
set lowercase os[:family] for OpenBSD

### DIFF
--- a/lib/specinfra/helper/detect_os/openbsd.rb
+++ b/lib/specinfra/helper/detect_os/openbsd.rb
@@ -1,7 +1,7 @@
 class Specinfra::Helper::DetectOs::Openbsd < Specinfra::Helper::DetectOs
   def self.detect
     if run_command('uname -s').stdout =~ /OpenBSD/i
-      { :family => 'OpenBSD', :release => nil }
+      { :family => 'openbsd', :release => nil }
     end
   end
 end


### PR DESCRIPTION
this is consistent with other os'es and adheres to the principle of least astonishment
