### PR TITLE
Implement routing table matcher for OpenBSD

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -160,6 +160,7 @@ require 'specinfra/command/openbsd/base/interface'
 require 'specinfra/command/openbsd/base/mail_alias'
 require 'specinfra/command/openbsd/base/package'
 require 'specinfra/command/openbsd/base/port'
+require 'specinfra/command/openbsd/base/routing_table'
 require 'specinfra/command/openbsd/base/service'
 require 'specinfra/command/openbsd/base/user'
 

--- a/lib/specinfra/command/openbsd/base/routing_table.rb
+++ b/lib/specinfra/command/openbsd/base/routing_table.rb
@@ -1,0 +1,9 @@
+class Specinfra::Command::Openbsd::Base::RoutingTable < Specinfra::Command::Base::RoutingTable
+  class << self
+    def check_has_entry(destination)
+      "route -n show -gateway | egrep '(^default|#{destination})' | head -1"
+    end
+
+    alias :get_entry :check_has_entry
+  end
+end

--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -123,12 +123,21 @@ module Specinfra
 
       ret.stdout.gsub!(/\r\n/, "\n")
 
-      ret.stdout =~ /^(\S+)(?: via (\S+))? dev (\S+).+\n(?:default via (\S+))?/
-      actual_attr = {
-        :destination => $1,
-        :gateway     => $2 ? $2 : $4,
-        :interface   => expected_attr[:interface] ? $3 : nil
-      }
+      if os[:family] == 'openbsd'
+        match = ret.stdout.match(/^(?<destination>\S+)\s+(?<gateway>\S+).*?(?<interface>\S+[0-9]+)$/)
+	actual_attr = {
+	  :destination => match[:destination],
+	  :gateway     => match[:gateway],
+	  :interface   => expected_attr[:interface] ? match[:interface] : nil
+	}
+      else
+        ret.stdout =~ /^(\S+)(?: via (\S+))? dev (\S+).+\n(?:default via (\S+))?/
+        actual_attr = {
+          :destination => $1,
+          :gateway     => $2 ? $2 : $4,
+          :interface   => expected_attr[:interface] ? $3 : nil
+        }
+      end
 
       expected_attr.each do |key, val|
         return false if actual_attr[key] != val


### PR DESCRIPTION
As discussed in #91 implemented with a conditional in `processor.rb`.
