### PR TITLE
Tweak routing table checks for OpenBSD

### DIFF
--- a/lib/specinfra/command/openbsd/base/routing_table.rb
+++ b/lib/specinfra/command/openbsd/base/routing_table.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Openbsd::Base::RoutingTable < Specinfra::Command::Base::RoutingTable
   class << self
     def check_has_entry(destination)
-      "route -n show -gateway | egrep '(^default|#{destination})' | head -1"
+      "route -n show -gateway | egrep '^#{destination}' | head -1"
     end
 
     alias :get_entry :check_has_entry

--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -124,7 +124,7 @@ module Specinfra
       ret.stdout.gsub!(/\r\n/, "\n")
 
       if os[:family] == 'openbsd'
-        match = ret.stdout.match(/^(?<destination>\S+)\s+(?<gateway>\S+).*?(?<interface>\S+[0-9]+)$/)
+        match = ret.stdout.match(/^(?<destination>\S+)\s+(?<gateway>\S+).*?(?<interface>\S+[0-9]+)(\s*)$/)
 	actual_attr = {
 	  :destination => match[:destination],
 	  :gateway     => match[:gateway],


### PR DESCRIPTION
- interfaces with shorter names (such as lo0) have whitespace appended, adjust
  the regex for this
- drop the 'default' match from the route(8) invocation.

This unbreaks a test such as:

``` ruby
    should have_entry(
      :destination => '127/8',
      :interface   => 'lo0',
      :gateway     => '127.0.0.1',
    )
```
