### PR TITLE
Use `pacman -Q` correctly to check for package name and version

### DIFF
--- a/lib/specinfra/command/arch.rb
+++ b/lib/specinfra/command/arch.rb
@@ -16,12 +16,12 @@ module SpecInfra
 
       def check_installed(package,version=nil)
         if version
-          "pacman -Q | grep #{escape(package)} #{escape(version)}"
+          grep = version.include?('-') ? "^#{escape(version)}$" : "^#{escape(version)}-"
+          "pacman -Q #{escape(package)} | awk '{print $2}' | grep '#{grep}'"
         else
-          "pacman -Q | grep #{escape(package)}"
+          "pacman -Q #{escape(package)}"
         end
       end
-
       def sync_repos
         "pacman -Syy"
       end


### PR DESCRIPTION
`pacman -Q | grep package_name` makes this pass:

```
describe package('lib') do
  it { should be_installed }
end
```

`pacman -Q package_name` is the way to go.

Also, version checking was totally broken. In `grep package_name version` command `version` is treated as a file name.

```
describe package('zsh') do
  it { should be_installed.with_version('5.0.6') }
end

grep: 5.0.6: No such file or directory
```

I fixed it, and introduced two options:
- '5.0.6' - will check for this particular version of software
- '5.0.6-1' - not only version of the software but also with an explicit [pkgrel](https://wiki.archlinux.org/index.php/PKGBUILD#pkgrel)

I'd be happy to write unit tests for all I did but I don't know how. Can you help please? Now it's tested in-place:

```
describe package('lib') do
  it { should_not be_installed }
end

describe package('zsh') do
  it { should_not be_installed.with_version('5.0.5') }
end

describe package('zsh') do
  it { should_not be_installed.with_version('5.0') }
end

describe package('zsh') do
  it { should_not be_installed.with_version('0.5') }
end

describe package('zsh') do
  it { should be_installed.with_version('5.0.6') }
end

describe package('zsh') do
  it { should be_installed.with_version('5.0.6-1') }
end

describe package('zsh') do
  it { should_not be_installed.with_version('5.0.6-2') }
end
```

By the way, `get_package_version` method isn't right too, but I'll fix it in a separate pull request after you help me implement tests. I have to find the best way to avoid the code duplication between `check_installed` and `get_pachage_version` first. :-)

```
      def get_package_version(package, opts=nil)
        "pacman -Q #{escape(package)} | grep Version | awk '{print $3}'"
      end
```

Also, please enable issues in your repository. I have two different problems in Arch Linux I'd like to report that I don't know how to fix, hence I'm not able to submit a patch. At least without your help. And a few other ideas, that I'd like to discuss before starting any coding:
- when requesting package + version, and package is installed but the version doesn't match, the message could say what version was found
- new resource type: `ping` - doing `ping -c 1 -W 1`
- new resource type: `host`: check what IP it resolves to, no matter it comes from /etc/hosts or from the DNS
- new resource type: `http`: some basic HTTP requests to make sure the webapp really works (`port(80).should be_listening` may not be enough).
- `command`: `succeed` instead of `return_exit_status 0`
- how to force distribution per spec? I use `linux-grsec` on one of my Arch Linuxes, and it doesn't contain `ARCH` in `uname -r`.
- it seems `\n` is prepended to any command output

```
  1) connection to hv1.alpha.virtkick.io Command "getent hosts hv1.alpha.virtkick.io" stdout should start with "10."
     On host `alpha.virtkick.io`
     Failure/Error: its(:stdout) { should start_with '10.' }
       sudo getent hosts hv1.alpha.virtkick.io

10.255.2.10     hv1.alpha.virtkick.io

       expected "\n10.255.2.10     hv1.alpha.virtkick.io\n" to start with "10."
     # ./spec/alpha.virtkick.io/apps_spec.rb:76:in `block (3 levels) in <top (required)>'
```
