### PR TITLE
Fix encoding to utf-8

### DIFF
--- a/lib/specinfra/command/arch.rb
+++ b/lib/specinfra/command/arch.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module SpecInfra
   module Command
     class Arch < Linux


### PR DESCRIPTION
Introduction of ● character fails to run on Ruby versions below 2.0.

  `invalid multibyte char (US-ASCII)`

This fixes error caught during a Test Kitchen run of Chef cookbooks.
