### PR TITLE
fix for unicode character in 9e2d79ef

### DIFF
--- a/lib/specinfra/command/arch.rb
+++ b/lib/specinfra/command/arch.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module SpecInfra
   module Command
     class Arch < Linux


### PR DESCRIPTION
specinfra release v1.27.4 seems to have broken some of my test-kitchen specs due to a Unicode character.  See below error `invalid multibyte char (US-ASCII)`.

https://github.com/rspec/rspec-rails/issues/66 referenced a similar fix.

```
$ bundle exec kitchen verify
-----> Starting Kitchen (v1.2.1)
-----> Setting up <default-centos-65>...
-----> Setting up Busser
       Creating BUSSER_ROOT in /tmp/busser
       Creating busser binstub
       Plugin serverspec already installed
       Finished setting up <default-centos-65> (0m5.58s).
-----> Verifying <default-centos-65>...
       Removing /tmp/busser/suites/serverspec
       Uploading /tmp/busser/suites/serverspec/localhost/default_spec.rb (mode=0644)
       Uploading /tmp/busser/suites/serverspec/spec_helper.rb (mode=0644)
-----> Running serverspec test suite
       /opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -S /opt/chef/embedded/bin/rspec /tmp/busser/suites/serverspec/localhost/default_spec.rb --color --format documentation
       /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require': /tmp/busser/gems/gems/specinfra-1.27.4/lib/specinfra/command/arch.rb:10: invalid multibyte char (US-ASCII) (SyntaxError)
       /tmp/busser/gems/gems/specinfra-1.27.4/lib/specinfra/command/arch.rb:10: invalid multibyte char (US-ASCII)
       /tmp/busser/gems/gems/specinfra-1.27.4/lib/specinfra/command/arch.rb:10: syntax error, unexpected $end, expecting keyword_end
       ...pendencies #{level} | grep '^● #{escape(service)}.service$...
       ...                               ^
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /tmp/busser/gems/gems/specinfra-1.27.4/lib/specinfra/command.rb:5:in `<top (required)>'
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /tmp/busser/gems/gems/specinfra-1.27.4/lib/specinfra.rb:4:in `<top (required)>'
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /tmp/busser/gems/gems/serverspec-1.16.0/lib/serverspec.rb:4:in `<top (required)>'
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:60:in `rescue in require'
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
        from /tmp/busser/suites/serverspec/spec_helper.rb:1:in `<top (required)>'
        from /tmp/busser/suites/serverspec/localhost/default_spec.rb:1:in `require_relative'
        from /tmp/busser/suites/serverspec/localhost/default_spec.rb:1:in `<top (required)>'
        from /tmp/busser/gems/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1065:in `load'
        from /tmp/busser/gems/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1065:in `block in load_spec_files'
        from /tmp/busser/gems/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1065:in `each'
        from /tmp/busser/gems/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1065:in `load_spec_files'
        from /tmp/busser/gems/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:18:in `run'
        from /tmp/busser/gems/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
        from /tmp/busser/gems/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'
       /opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -S /opt/chef/embedded/bin/rspec /tmp/busser/suites/serverspec/localhost/default_spec.rb --color --format documentation failed
       Ruby Script [/tmp/busser/gems/gems/busser-serverspec-0.2.7/lib/busser/runner_plugin/../serverspec/runner.rb /tmp/busser/suites/serverspec] exit code was 1v
```
