### PR TITLE
Use corrected stat method for FreeBSD

### DIFF
--- a/lib/specinfra/command/freebsd/base/file.rb
+++ b/lib/specinfra/command/freebsd/base/file.rb
@@ -1,5 +1,13 @@
 class Specinfra::Command::Freebsd::Base::File < Specinfra::Command::Base::File
   class << self
+    def get_owner_user(file)
+      "stat -f%Su #{escape(file)}"
+    end
+
+    def get_owner_group(file)
+      "stat -f%Sg #{escape(file)}"
+    end
+
     def check_grouped(file, group)
       regexp = "^#{group}$"
       "stat -f%Sg #{escape(file)} | grep -- #{escape(regexp)}"

--- a/spec/command/freebsd/file_spec.rb
+++ b/spec/command/freebsd/file_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+set :os, :family => 'freebsd'
+
+describe get_command(:get_file_owner_user, '/tmp') do
+  it { should eq 'stat -f%Su /tmp' }
+end
+
+describe get_command(:get_file_owner_group, '/tmp') do
+  it { should eq 'stat -f%Sg /tmp' }
+end


### PR DESCRIPTION
This PR addresses the following when running specs on an actual FreeBSD machine:

```
  1) File "/data" should be owned by "my_account"
     On host `xxx.xxx.xxx'
     Failure/Error: it { should be_owned_by 'my_account' }
       expected `File "/data".owned_by?("my_account")` to return true, got false
       /bin/sh -c stat\ -c\ \%U\ /data\ \|\ grep\ --\ \\\^my_account\\\$

     # ./spec/xxx.xxx.xxx/files_spec.rb:15:in `block (3 levels) in <top (required)>'

  2) File "/data" should be grouped into "my_account"
     On host `xxx.xxx.xxx'
     Failure/Error: it { should be_grouped_into 'my_account' }
       expected `File "/data".grouped_into?("my_account")` to return true, got false
       /bin/sh -c stat\ -c\ \%G\ /data\ \|\ grep\ --\ \\\^my_account\\\$

     # ./spec/xxx.xxx.xxx/files_spec.rb:16:in `block (3 levels) in <top (required)>'
```

Somewhat strangely, the following new specs pass:
`bundle exe rspec spec/command/freebsd/file_spec.rb`

But, when run as part of the full suite the same specs fail:
`bundle exec rake spec:command`

I'm not sure why this is, and I thought I'd send the PR as a request for help. My initial investigation indicates the property[:os] is not updated by the `set :os, :family => 'freebsd'` line at the top of the file, but I'm not sure why. 

Thanks! 
