### PR TITLE
Fix FreeBSD method names for file checks

### DIFF
--- a/lib/specinfra/command/freebsd/base/file.rb
+++ b/lib/specinfra/command/freebsd/base/file.rb
@@ -1,19 +1,11 @@
 class Specinfra::Command::Freebsd::Base::File < Specinfra::Command::Base::File
   class << self
-    def get_owner_user(file)
-      "stat -f%Su #{escape(file)}"
-    end
-
-    def get_owner_group(file)
-      "stat -f%Sg #{escape(file)}"
-    end
-
-    def check_grouped(file, group)
+    def check_is_grouped(file, group)
       regexp = "^#{group}$"
       "stat -f%Sg #{escape(file)} | grep -- #{escape(regexp)}"
     end
 
-    def check_owner(file, owner)
+    def check_is_owned_by(file, owner)
       regexp = "^#{owner}$"
       "stat -f%Su #{escape(file)} | grep -- #{escape(regexp)}"
     end

--- a/spec/command/freebsd/file_spec.rb
+++ b/spec/command/freebsd/file_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 property[:os] = nil
 set :os, :family => 'freebsd'
 
-describe get_command(:get_file_owner_user, '/tmp') do
-  it { should eq 'stat -f%Su /tmp' }
+describe get_command(:check_file_is_owned_by, '/tmp', 'root') do
+  it { should eq 'stat -f%Su /tmp | grep -- \\^root\\$' }
 end
 
-describe get_command(:get_file_owner_group, '/tmp') do
-  it { should eq 'stat -f%Sg /tmp' }
+describe get_command(:check_file_is_grouped, '/tmp', 'wheel') do
+  it { should eq 'stat -f%Sg /tmp | grep -- \\^wheel\\$' }
 end


### PR DESCRIPTION
Updated method names and tested locally with Vagrant FreeBSD instance. My apologies for the previous, ineffective PR. I'll send additional PR for other FreeBSD items as I encounter them.
