### PR TITLE
Make sure pkgutil command always gets returned

### DIFF
--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -15,6 +15,7 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     def check_is_installed_by_pkgutil(package, version=nil)
       cmd = "pkgutil --pkg-info #{package}"
       cmd = "#{cmd} | grep '^version: #{escape(version)}'" if version
+      cmd
     end
 
     def install(package, version=nil, option='')


### PR DESCRIPTION
There was a bug where, if no version is provided, this method would return `nil` instead of the command string.
