### PR TITLE
[EXPERIMENTAL] Add function to get ec2 metadata to inventory helper

### DIFF
--- a/lib/specinfra/ec2_metadata.rb
+++ b/lib/specinfra/ec2_metadata.rb
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+module Specinfra
+  class Ec2Metadata
+    def initialize
+      @base_uri = 'http://169.254.169.254/latest/meta-data/'
+    end
+
+    def get(path='')
+      metadata = {}
+
+      keys = Specinfra::Runner.run_command("curl #{@base_uri}#{path}").stdout.split("\n")
+
+      keys.each do |key|
+        if key =~ %r{/$}
+          metadata[key[0..-2]] = get(path + key)
+        else
+          if key =~ %r{=}
+            key = key.split('=')[0] + '/'
+            metadata[key[0..-2]] = get(path + key)
+          else
+            ret = get_endpoint(path)
+            metadata[key] = get_endpoint(path + key) if ret
+          end
+        end
+      end
+
+      metadata
+    end
+
+    def get_endpoint(path)
+      ret = Specinfra::Runner.run_command("curl #{@base_uri}#{path}")
+      if ret.success?
+        ret.stdout
+      else
+        nil
+      end
+    end
+
+  end
+end

--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -1,3 +1,5 @@
+require 'specinfra/ec2_metadata'
+
 module Specinfra
   class Processor
     def self.check_service_is_running(service)
@@ -180,6 +182,10 @@ module Specinfra
         end
       end
       memory
+    end
+
+    def self.get_inventory_ec2
+      Specinfra::Ec2Metadata.new.get
     end
   end
 end


### PR DESCRIPTION
You can get ec2 metadata like this.

``` ruby
pp host_inventory[:ec2]

{"ami-id"=>"ami-29dc9228",
 "ami-launch-index"=>"0",
 "ami-manifest-path"=>"(unknown)",
 "block-device-mapping"=>{"ami"=>"/dev/xvda", "root"=>"/dev/xvda"},
 "hostname"=>"ip-172-30-1-248.ap-northeast-1.compute.internal",
 "instance-action"=>"none",
 "instance-id"=>"i-fdcea4e4",
 "instance-type"=>"t2.micro",
 "local-hostname"=>"ip-172-30-1-248.ap-northeast-1.compute.internal",
 "local-ipv4"=>"172.30.1.248",
 "mac"=>"06:9f:24:59:0d:08",
 "metrics"=>{"vhostmd"=>"<?xml version=\"1.0\" encoding=\"UTF-8\"?>"},
 "network"=>
  {"interfaces"=>
    {"macs"=>
      {"06:9f:24:59:0d:08"=>
        {"device-number"=>"0",
         "interface-id"=>"eni-10830467",
         "ipv4-associations"=>{"54.64.124.181"=>"172.30.1.248"},
         "local-hostname"=>"ip-172-30-1-248.ap-northeast-1.compute.internal",
         "local-ipv4s"=>"172.30.1.248",
         "mac"=>"06:9f:24:59:0d:08",
         "owner-id"=>"853708250916",
         "public-hostname"=>"",
         "public-ipv4s"=>"54.64.124.181",
         "security-group-ids"=>"sg-597bbc3c",
         "security-groups"=>"launch-wizard-3",
         "subnet-id"=>"subnet-6654bd11",
         "subnet-ipv4-cidr-block"=>"172.30.1.0/24",
         "vpc-id"=>"vpc-3108e254",
         "vpc-ipv4-cidr-block"=>"172.30.0.0/16"}}}},
 "placement"=>{"availability-zone"=>"ap-northeast-1b"},
 "profile"=>"default-hvm",
 "public-hostname"=>"",
 "public-ipv4"=>"54.64.124.181",
 "public-keys"=>
  {"0"=>
    {"openssh-key"=>
      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCBgoqZg320DAgdessGJXTadkkQ9HHd552na9nERPiOU36WU1DE83CHDrCi7rToPLji0M+l1Vi8yXUrqPkTeC2AY7HpbG2aY+7ReLtsZin+gB2+oEMk3UGQP29foG3AB6syy7n9lm71qz9q91tItaBMszVNH7oRC1a7ZB8eJx6hNAid8uD8zsvmldOLZ+rCWTRBJLbjEm3AYTFfduL/1wptA+/7u7CJ8rRCxg4Dfwja0APTZeyjL31w3AraGTlQL0IxxTjogVb1AoGbpWC8RjUfV/IAGJGntpIJF1J+tayDSCIpvic9oi9DqGmijZpnwisdVCn88o9yL9vJ7Wpj4iDt miya\n"}},
 "reservation-id"=>"r-66490760",
 "security-groups"=>"launch-wizard-3",
 "services"=>{"domain"=>"amazonaws.com"}}
{"ami-id"=>"ami-29dc9228",
 "ami-launch-index"=>"0",
 "ami-manifest-path"=>"(unknown)",
 "block-device-mapping"=>{"ami"=>"/dev/xvda", "root"=>"/dev/xvda"},
 "hostname"=>"ip-172-30-1-248.ap-northeast-1.compute.internal",
 "instance-action"=>"none",
 "instance-id"=>"i-fdcea4e4",
 "instance-type"=>"t2.micro",
 "local-hostname"=>"ip-172-30-1-248.ap-northeast-1.compute.internal",
 "local-ipv4"=>"172.30.1.248",
 "mac"=>"06:9f:24:59:0d:08",
 "metrics"=>{"vhostmd"=>"<?xml version=\"1.0\" encoding=\"UTF-8\"?>"},
 "network"=>
  {"interfaces"=>
    {"macs"=>
      {"06:9f:24:59:0d:08"=>
        {"device-number"=>"0",
         "interface-id"=>"eni-10830467",
         "ipv4-associations"=>{"54.64.124.181"=>"172.30.1.248"},
         "local-hostname"=>"ip-172-30-1-248.ap-northeast-1.compute.internal",
         "local-ipv4s"=>"172.30.1.248",
         "mac"=>"06:9f:24:59:0d:08",
         "owner-id"=>"853708250916",
         "public-hostname"=>"",
         "public-ipv4s"=>"54.64.124.181",
         "security-group-ids"=>"sg-597bbc3c",
         "security-groups"=>"launch-wizard-3",
         "subnet-id"=>"subnet-6654bd11",
         "subnet-ipv4-cidr-block"=>"172.30.1.0/24",
         "vpc-id"=>"vpc-3108e254",
         "vpc-ipv4-cidr-block"=>"172.30.0.0/16"}}}},
 "placement"=>{"availability-zone"=>"ap-northeast-1b"},
 "profile"=>"default-hvm",
 "public-hostname"=>"",
 "public-ipv4"=>"54.64.124.181",
 "public-keys"=>
  {"0"=>
    {"openssh-key"=>
      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCBgoqZg320DAgdessGJXTadkkQ9HHd552na9nERPiOU36WU1DE83CHDrCi7rToPLji0M+l1Vi8yXUrqPkTeC2AY7HpbG2aY+7ReLtsZin+gB2+oEMk3UGQP29foG3AB6syy7n9lm71qz9q91tItaBMszVNH7oRC1a7ZB8eJx6hNAid8uD8zsvmldOLZ+rCWTRBJLbjEm3AYTFfduL/1wptA+/7u7CJ8rRCxg4Dfwja0APTZeyjL31w3AraGTlQL0IxxTjogVb1AoGbpWC8RjUfV/IAGJGntpIJF1J+tayDSCIpvic9oi9DqGmijZpnwisdVCn88o9yL9vJ7Wpj4iDt miya\n"}},
 "reservation-id"=>"r-66490760",
 "security-groups"=>"launch-wizard-3",
 "services"=>{"domain"=>"amazonaws.com"}}
{"ami-id"=>"ami-29dc9228",
 "ami-launch-index"=>"0",
 "ami-manifest-path"=>"(unknown)",
 "block-device-mapping"=>{"ami"=>"/dev/xvda", "root"=>"/dev/xvda"},
 "hostname"=>"ip-172-30-1-248.ap-northeast-1.compute.internal",
 "instance-action"=>"none",
 "instance-id"=>"i-fdcea4e4",
 "instance-type"=>"t2.micro",
 "local-hostname"=>"ip-172-30-1-248.ap-northeast-1.compute.internal",
 "local-ipv4"=>"172.30.1.248",
 "mac"=>"06:9f:24:59:0d:08",
 "metrics"=>{"vhostmd"=>"<?xml version=\"1.0\" encoding=\"UTF-8\"?>"},
 "network"=>
  {"interfaces"=>
    {"macs"=>
      {"06:9f:24:59:0d:08"=>
        {"device-number"=>"0",
         "interface-id"=>"eni-10830467",
         "ipv4-associations"=>{"54.64.124.181"=>"172.30.1.248"},
         "local-hostname"=>"ip-172-30-1-248.ap-northeast-1.compute.internal",
         "local-ipv4s"=>"172.30.1.248",
         "mac"=>"06:9f:24:59:0d:08",
         "owner-id"=>"853708250916",
         "public-hostname"=>"",
         "public-ipv4s"=>"54.64.124.181",
         "security-group-ids"=>"sg-597bbc3c",
         "security-groups"=>"launch-wizard-3",
         "subnet-id"=>"subnet-6654bd11",
         "subnet-ipv4-cidr-block"=>"172.30.1.0/24",
         "vpc-id"=>"vpc-3108e254",
         "vpc-ipv4-cidr-block"=>"172.30.0.0/16"}}}},
 "placement"=>{"availability-zone"=>"ap-northeast-1b"},
 "profile"=>"default-hvm",
 "public-hostname"=>"",
 "public-ipv4"=>"54.64.124.181",
 "public-keys"=>
  {"0"=>
    {"openssh-key"=>
      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCBgoqZg320DAgdessGJXTadkkQ9HHd552na9nERPiOU36WU1DE83CHDrCi7rToPLji0M+l1Vi8yXUrqPkTeC2AY7HpbG2aY+7ReLtsZin+gB2+oEMk3UGQP29foG3AB6syy7n9lm71qz9q91tItaBMszVNH7oRC1a7ZB8eJx6hNAid8uD8zsvmldOLZ+rCWTRBJLbjEm3AYTFfduL/1wptA+/7u7CJ8rRCxg4Dfwja0APTZeyjL31w3AraGTlQL0IxxTjogVb1AoGbpWC8RjUfV/IAGJGntpIJF1J+tayDSCIpvic9oi9DqGmijZpnwisdVCn88o9yL9vJ7Wpj4iDt miya\n"}},
 "reservation-id"=>"r-66490760",
 "security-groups"=>"launch-wizard-3",
 "services"=>{"domain"=>"amazonaws.com"}}
```
