### PR TITLE
fix be_running matche for Solaris

### DIFF
--- a/lib/specinfra/command/solaris/base/service.rb
+++ b/lib/specinfra/command/solaris/base/service.rb
@@ -4,7 +4,7 @@ class Specinfra::Command::Solaris::Base::Service < Specinfra::Command::Base::Ser
       "svcs -l #{escape(service)} 2> /dev/null | egrep '^enabled *true$'"
     end
 
-    def check_running(service)
+    def check_is_running(service)
       "svcs -l #{escape(service)} status 2> /dev/null | egrep '^state *online$'"
     end
 


### PR DESCRIPTION
be_running matcher of service resource type always fails on Solaris,
Because "check_is_running" for Solaris is not defined.

"check_running" defined in lib/specinfra/command/solaris/base/service.rb should be "check_is_running".
Then rename it.
