### PR TITLE
fix command of service check_is_running for Solaris

### DIFF
--- a/lib/specinfra/command/solaris/base/service.rb
+++ b/lib/specinfra/command/solaris/base/service.rb
@@ -5,7 +5,7 @@ class Specinfra::Command::Solaris::Base::Service < Specinfra::Command::Base::Ser
     end
 
     def check_is_running(service)
-      "svcs -l #{escape(service)} status 2> /dev/null | egrep '^state *online$'"
+      "svcs -H -o state #{escape(service)} 2> /dev/null | egrep '^online$'"
     end
 
     def check_has_property(svc, property)


### PR DESCRIPTION
Command of service check_is_running for Solaris is incorrect,
and can not check correctly when service "svc:/network/nfs/status:default" exists.
