### PR TITLE
Add get_package_version support of darwin

### DIFF
--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -22,6 +22,10 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
       # Homebrew doesn't support to install specific version.
       cmd = "brew install #{option} '#{package}'"
     end
+
+    def get_version(package, opts=nil)
+      "basename $(brew info mysql | grep '\*$' | awk '{print $1}')"
+    end
   end
 end
 


### PR DESCRIPTION
When I tried to use `itamae local` on OSX, it failed to execute `get_package_version` with specinfra.
So I'm happy if `get_version` of package for darwin is supported.
## example (for review)

``` bash
$ ls -l /usr/local/bin/mysql
lrwxr-xr-x  1 k0kubun  admin  32  7  8 00:26 /usr/local/bin/mysql -> ../Cellar/mysql/5.6.19/bin/mysql
$ brew info mysql
mysql: stable 5.6.21
http://dev.mysql.com/doc/refman/5.6/en/
Conflicts with: mariadb, mysql-cluster, mysql-connector-c, percona-server
/usr/local/Cellar/mysql/5.6.15 (9410 files, 349M)
  Poured from bottle
/usr/local/Cellar/mysql/5.6.16 (9424 files, 349M)
  Poured from bottle
/usr/local/Cellar/mysql/5.6.19 (9536 files, 338M) *
  Poured from bottle
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/mysql.rb
...
$ basename $(brew info mysql | grep '\*$' | awk '{print $1}')
5.6.19
```
