### PR TITLE
Avoid regexp warnings with Ruby < 1.9

### DIFF
--- a/lib/specinfra/helper/detect_os/debian.rb
+++ b/lib/specinfra/helper/detect_os/debian.rb
@@ -20,7 +20,7 @@ class Specinfra::Helper::DetectOs::Debian < Specinfra::Helper::DetectOs
       end
       distro ||= 'debian'
       release ||= nil
-      { :family => distro.gsub(/\p{^Alnum}/, '').downcase, :release => release }
+      { :family => distro.gsub(/[^[:alnum:]]/, '').downcase, :release => release }
     end
   end
 end


### PR DESCRIPTION
Change regexp to avoid two warnings with older rubies.

As seen with the original regexp with ruby 1.8.7-p374 while running `rake spec`:

```
...
/tmp/specinfra/lib/specinfra/helper/detect_os/debian.rb:23: warning: regexp has invalid interval
/tmp/specinfra/lib/specinfra/helper/detect_os/debian.rb:23: warning: regexp has `}' without escape
...
```
