### PR TITLE
fix Specinfra::Command::Solaris::Base::Cron

### DIFF
--- a/lib/specinfra/command/solaris/base/cron.rb
+++ b/lib/specinfra/command/solaris/base/cron.rb
@@ -1,6 +1,6 @@
 class Specinfra::Command::Solaris::Base::Cron < Specinfra::Command::Base::Cron
   class << self
-    def check_cron_entry(user, entry)
+    def check_has_entry(user, entry)
       entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]')
       if user.nil?
         "crontab -l | grep -- #{escape(entry_escaped)}"


### PR DESCRIPTION
'check_cron_entry' defined in Specinfra::Command::Solaris::Base::Cron is incorrect.
It should be 'check_has_entry'  like Specinfra::Command::Base::Cron.
