### PR TITLE
Strip first newline when sudo

### DIFF
--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -13,6 +13,7 @@ module Specinfra::Backend
       end
 
       ret[:stdout].gsub!(/\r\n/, "\n")
+      ret[:stdout].gsub!(/\A\n/, "") if sudo?
 
       if @example
         @example.metadata[:command] = cmd
@@ -35,9 +36,7 @@ module Specinfra::Backend
 
     def build_command(cmd)
       cmd = super(cmd)
-      user = Specinfra.configuration.ssh_options[:user]
-      disable_sudo = Specinfra.configuration.disable_sudo
-      if user != 'root' && !disable_sudo
+      if sudo?
         cmd = "#{sudo} -p '#{prompt}' #{cmd}"
       end
       cmd
@@ -155,6 +154,12 @@ module Specinfra::Backend
       end
 
       "#{sudo_path.shellescape}#{sudo_options}"
+    end
+
+    def sudo?
+      user = Specinfra.configuration.ssh_options[:user]
+      disable_sudo = Specinfra.configuration.disable_sudo
+      user != 'root' && !disable_sudo
     end
   end
 end


### PR DESCRIPTION
## Problem

When I execute `itamae ssh` by non-root user, all stdout is prefixed by `"\n"`.
Thus a part of itamae's debug output becomes like:

```
DEBUG :          Executing `stat -c %a /home/k0kubun/.ssh`...
DEBUG :             exited with 0
DEBUG :             stdout |
DEBUG :             stdout | 700
 INFO :          mode will change from '
700' to '700'
```

When command is prefixed by `sudo -p 'Password: '` and password is inputted with `send_data`, it seems `"\r\n"` is printed before command's stdout.
## Solution

Trimming the newline if command is prefixed by `sudo -p 'Password: '`.
With this patch, itamae's debug output changed to:

```
DEBUG :          Executing `stat -c %a /home/k0kubun/.ssh`...
DEBUG :             exited with 0
DEBUG :             stdout | 700
DEBUG :          mode will not change (current value is '700')
```
