### PR TITLE
Fix check_has_entry for routing table

### DIFF
--- a/lib/specinfra/command/base/routing_table.rb
+++ b/lib/specinfra/command/base/routing_table.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Base::RoutingTable < Specinfra::Command::Base
   class << self
     def check_has_entry(destination)
-      "ip route | grep -E '^#{destination} |^default '"
+      "ip route | grep -E '^#{destination} '"
     end
 
     alias :get_entry :check_has_entry


### PR DESCRIPTION
- removed ^default from regex

On my debian box, having the command check for 

``` shell
ip route | grep -E '^#{destination} |^default '
```

fails, whereas without the ^default, it works as expected.

Since a destination has to be supplied and since that destination can be 'default' as well, I do not see why this needs to be in here.

Cheers,
Sven
