### PR TITLE
Add dockerfile_finalizer to Specinfra::Configuration

### DIFF
--- a/lib/specinfra/backend/dockerfile.rb
+++ b/lib/specinfra/backend/dockerfile.rb
@@ -4,7 +4,11 @@ module Specinfra::Backend
     def initialize
       @lines = []
       ObjectSpace.define_finalizer(self) {
-        puts @lines
+        if Specinfra.configuration.dockerfile_finalizer.nil?
+          puts @lines
+        else
+          Specinfra.configuration.dockerfile_finalizer.call(@lines)
+        end
       }
     end
 

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -17,6 +17,7 @@ module Specinfra
         :lxc,
         :request_pty,
         :ssh_options,
+        :dockerfile_finalizer,
       ].freeze
 
       def defaults


### PR DESCRIPTION
This is necessary for saving `Dockerfile` or other processing.
