### PR TITLE
Serverspec host

### DIFF
--- a/lib/specinfra/command/base/host.rb
+++ b/lib/specinfra/command/base/host.rb
@@ -27,7 +27,7 @@ class Specinfra::Command::Base::Host < Specinfra::Command::Base
     end
 
     def get_domain
-      "hostname -d"
+      "dnsdomainname"
     end
 
     def get_fqdn


### PR DESCRIPTION
Matching PR for Serverspec PR #488

Adds three backend commands for the host resource. 'get_name', 'get_domain' and 'get_fqdn'. These should all work on any vaguely *nixish system.
