### PR TITLE
Add hostname, domain and fqdn to host_inventory

### DIFF
--- a/lib/specinfra/command/linux/base/inventory.rb
+++ b/lib/specinfra/command/linux/base/inventory.rb
@@ -3,5 +3,17 @@ class Specinfra::Command::Linux::Base::Inventory < Specinfra::Command::Base::Inv
     def get_memory
       'cat /proc/meminfo'
     end
+
+    def get_hostname
+      'hostname -s'
+    end
+
+    def get_domain
+      'dnsdomainame'
+    end
+
+    def get_fqdn
+      'hostname -f'
+    end
   end
 end

--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -187,5 +187,20 @@ module Specinfra
     def self.get_inventory_ec2
       Specinfra::Ec2Metadata.new.get
     end
+
+    def self.get_inventory_hostname
+      cmd = Specinfra.command.get(:get_inventory_hostname)
+      Specinfra.backend.run_command(cmd).stdout.strip
+    end
+
+    def self.get_inventory_domain
+      cmd = Specinfra.command.get(:get_inventory_domain)
+      Specinfra.backend.run_command(cmd).stdout.strip
+    end
+
+    def self.get_inventory_fqdn
+      cmd = Specinfra.command.get(:get_inventory_fqdn)
+      Specinfra.backend.run_command(cmd).stdout.strip
+    end
   end
 end


### PR DESCRIPTION
You can get hostname, domain and fqdn like this with this pull request.

``` ruby
puts host_inventory['hostname']
puts host_inventory['domain']
puts host_inventory['fqdn']
```
