### PR TITLE
Fix host inventory 263

### DIFF
--- a/lib/specinfra/command/linux/base/inventory.rb
+++ b/lib/specinfra/command/linux/base/inventory.rb
@@ -9,7 +9,7 @@ class Specinfra::Command::Linux::Base::Inventory < Specinfra::Command::Base::Inv
     end
 
     def get_domain
-      'dnsdomainame'
+      'dnsdomainname'
     end
 
     def get_fqdn


### PR DESCRIPTION
The changes in PR #263 has a typo: "dnsdomainame" instead of "dnsdomainname", which means the "host_inventory['domain']" resource fails.
