### PR TITLE
It's fix that docker_image of serverspec is conflicting.

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -32,7 +32,7 @@ module Specinfra::Backend
     private
 
     def base_image
-      @base_image ||= ::Docker::Image.get(Specinfra.configuration.docker_image)
+      @base_image ||= ::Docker::Image.get(Specinfra.configuration.docker_img)
     end
 
     def current_image

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -12,7 +12,7 @@ module Specinfra
         :sudo_path,
         :disable_sudo,
         :sudo_options,
-        :docker_image,
+        :docker_img,
         :docker_url,
         :lxc,
         :request_pty,


### PR DESCRIPTION
Specinfra.configuration.docker_image is overwritten by https://github.com/serverspec/serverspec/pull/482
That can probably be corrected by this patch.
