### PR TITLE
fix get_file_owner_(user|group) for darwin

### DIFF
--- a/lib/specinfra/command/darwin/base/file.rb
+++ b/lib/specinfra/command/darwin/base/file.rb
@@ -34,6 +34,14 @@ class Specinfra::Command::Darwin::Base::File < Specinfra::Command::Base::File
     def get_mode(file)
       "stat -f%Lp #{escape(file)}"
     end
+
+    def get_owner_user(file)
+      "stat -f %Su #{escape(file)}"
+    end
+
+    def get_owner_group(file)
+      "stat -f %Sg #{escape(file)}"
+    end
   end
 end
 


### PR DESCRIPTION
I  tried to use local on OSX(for itamae). So I found a failure case of `stat` command.

`stat -c` option not support for darwin . I was fixed option of `stat -f`

execute logs.

```
$ ls -l /tmp/ | grep hoge
drwxr-xr-x  2 sugamasao  wheel   68 12  2 23:50 hoge
```

``` ruby
[1] pry(main)> require 'specinfra'
=> true
[2] pry(main)> Specinfra.configuration.backend = :exec
=> :exec
[3] pry(main)> Specinfra::Helper.os
=> {:family=>"darwin", :release=>nil, :arch=>"x86_64"}
[4] pry(main)> command = Specinfra.command.get(:get_file_owner_user, '/tmp/hoge')
=> "stat -c %U /tmp/hoge"
[5] pry(main)> Specinfra.backend.run_command(command).stdout
=> "stat: illegal option -- c\nusage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]\n"
[6] pry(main)> command = Specinfra.command.get(:get_file_owner_group, '/tmp/hoge')
=> "stat -c %G /tmp/hoge"
[7] pry(main)> Specinfra.backend.run_command(command).stdout
=> "stat: illegal option -- c\nusage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]\n"
```

fix it.

``` ruby
irb(main):001:0> require 'specinfra'
=> true
irb(main):002:0> Specinfra.configuration.backend = :exec
=> :exec
irb(main):003:0> Specinfra::Helper.os
=> {:family=>"darwin", :release=>nil, :arch=>"x86_64"}
irb(main):004:0> command = Specinfra.command.get(:get_file_owner_user, '/tmp/hoge')
=> "stat -f %Su /tmp/hoge"
irb(main):005:0> Specinfra.backend.run_command(command).stdout
=> "sugamasao\n"
irb(main):006:0> command = Specinfra.command.get(:get_file_owner_group, '/tmp/hoge')
=> "stat -f %Sg /tmp/hoge"
irb(main):007:0> Specinfra.backend.run_command(command).stdout
=> "wheel\n"
```
