### PR TITLE
Get docker image in initialize

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -9,6 +9,7 @@ module Specinfra::Backend
 
       @images = []
       ::Docker.url = Specinfra.configuration.docker_url
+      @base_image = ::Docker::Image.get(Specinfra.configuration.docker_image)
     end
 
     def run_command(cmd, opts={})
@@ -31,12 +32,8 @@ module Specinfra::Backend
 
     private
 
-    def base_image
-      @base_image ||= ::Docker::Image.get(Specinfra.configuration.docker_image)
-    end
-
     def current_image
-      @images.last || base_image
+      @images.last || @base_image
     end
 
     def docker_run!(cmd, opts={})


### PR DESCRIPTION
In the RSpec example group, `Specinfra.configuration.docker_image` conflicts with `docker_image` method defined by `serverspec/helper/type.rb`.

So Docker backend gets a base image in its initialize phase with this fix.

Ref #269 
