### PR TITLE
removing an unmatched square bracket in the windows file resource

### DIFF
--- a/lib/specinfra/command/windows/base/file.rb
+++ b/lib/specinfra/command/windows/base/file.rb
@@ -34,11 +34,11 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
         exec cmd
       end
     end
-  
+
     def get_content(file)
       %Q![Io.File]::ReadAllText("#{file}")!
     end
-  
+
     def check_is_accessible_by_user(file, user, access)
       case access
       when 'r'
@@ -73,7 +73,7 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
 
     def check_contains(file, pattern)
       Backend::PowerShell::Command.new do
-        exec %Q![[Io.File]::ReadAllText("#{file}") -match '#{convert_regexp(pattern)}'!
+        exec %Q![Io.File]::ReadAllText("#{file}") -match '#{convert_regexp(pattern)}'!
       end
     end
 


### PR DESCRIPTION
An unmatched square bracket in the file contains check causes explosions. I notice the repo is - uh - a little light on tests for Windows platforms, but here's some console output from the failed run:

```
File "c:/hello.world"
  should contain "yoyoyo" (FAILED - 1)

Failures:

  1) File "c:/hello.world" should contain "yoyoyo"
     On host `my.hostname.example'
     Failure/Error: it {should contain 'yoyoyo'}
       expected File "c:/hello.world" to contain "yoyoyo"
       $exitCode = 1
$ProgressPreference = "SilentlyContinue"
try {
```

  $success = (**[**[Io.File]::ReadAllText("c:/hello.world") -match 'yoyoyo')

```
  if ($success -is [Boolean] -and $success) { $exitCode = 0 }
} catch {
  Write-Output $_.Exception.Message
}
Write-Output "Exiting with code: $exitCode"
exit $exitCode

       #< CLIXML
<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><S S="Error">
```

**Missing ] at end of type token.**

```
_x000D__x000A_</S><S S="Error">At line:5 char:73_x000D__x000A_</S><S S="Error">+   $success = ([[Io.File]::ReadAllText("c:/hello.world") -match 'yoyoyo')
 &lt;&lt;&lt;&lt;_x000D__x000A_</S><S S="Error"> _x000D__x000A_</S><S S="Error">
    + CategoryInfo          : ParserError: ([Io.File]::Read...match 'yoyoyo'): _x000D__x000A_</S><S S="Error">   String) [], ParentContainsErrorRecordException_x000D__x000A_</S><S S="Error">    + FullyQualifiedErrorId : EndSquareBracketExpectedAtEndOfType_x000D__x000A_</S><S S="Error"> _x000D__x000A_</S></Objs>
```

After removing the unmatched bracket, it succeeds. Note: This is on win2k8r2 and powershell 2.0.
