### PR TITLE
single \ to properly escape . in check_has_ipv4_address

### DIFF
--- a/lib/specinfra/command/linux/base/interface.rb
+++ b/lib/specinfra/command/linux/base/interface.rb
@@ -15,7 +15,7 @@ class Specinfra::Command::Linux::Base::Interface < Specinfra::Command::Base::Int
       else
         ip_address << "/"
       end
-      ip_address.gsub!(".", "\\.")
+      ip_address.gsub!(".", "\.")
       "ip addr show #{interface} | grep 'inet #{ip_address}'"
     end
 


### PR DESCRIPTION
```
Failure/Error: it { should have_ipv4_address('10.1.1.129') }
[#]        expected #has_ipv4_address?("10.1.1.129") to return true, got false
[#]        /bin/sh -c ip\ addr\ show\ tun0\ \|\ grep\ \'inet\ 10\\.1\\.1\\.129/\'
```

```
root@localhost:~# ip addr show tun0 | grep 'inet 10\\.1\\.1\\.129'
root@localhost:~#
```

```
root@localhost:~# ip addr show tun0 | grep 'inet 10\.1\.1\.129'
    inet 10.1.1.129 peer 10.1.1.130/32 scope global tun0
root@localhost:~#
```
