### PR TITLE
Implement bridge resource type for OpenBSD

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -167,6 +167,7 @@ require 'specinfra/command/freebsd/v10/package'
 # OpenBSD (inherit Base)
 require 'specinfra/command/openbsd'
 require 'specinfra/command/openbsd/base'
+require 'specinfra/command/openbsd/base/bridge'
 require 'specinfra/command/openbsd/base/file'
 require 'specinfra/command/openbsd/base/interface'
 require 'specinfra/command/openbsd/base/mail_alias'

--- a/lib/specinfra/command/openbsd/base/bridge.rb
+++ b/lib/specinfra/command/openbsd/base/bridge.rb
@@ -1,0 +1,11 @@
+class Specinfra::Command::Openbsd::Base::Bridge < Specinfra::Command::Base::Bridge
+  class << self
+    def check_exists(name)
+      "ifconfig #{name}"
+    end
+
+    def check_has_interface(name, interface)
+      "ifconfig #{name} | grep -o #{interface}"
+    end
+  end
+end


### PR DESCRIPTION
Two small notes:
- bridges are just regular interfaces on OpenBSD, so we can just use ifconfig(8).
- no spec tests as there are currently none for OpenBSD, I'll work on those later as a separate PR.
