### PR TITLE
Allow check_is_(grouped,owned_by) matchers to use numeric GID/UID

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -26,12 +26,20 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
 
     def check_is_grouped(file, group)
       regexp = "^#{group}$"
-      "stat -c %G #{escape(file)} | grep -- #{escape(regexp)}"
+      if group.is_a?(Numeric) || (group =~ /\A\d+\z/ ? true : false)
+        "stat -c %g #{escape(file)} | grep -- #{escape(regexp)}"
+      else
+        "stat -c %G #{escape(file)} | grep -- #{escape(regexp)}"
+      end
     end
 
     def check_is_owned_by(file, owner)
       regexp = "^#{owner}$"
-      "stat -c %U #{escape(file)} | grep -- #{escape(regexp)}"
+      if owner.is_a?(Numeric) || (owner =~ /\A\d+\z/ ? true : false)
+        "stat -c %u #{escape(file)} | grep -- #{escape(regexp)}"
+      else
+        "stat -c %U #{escape(file)} | grep -- #{escape(regexp)}"
+      end
     end
 
     def check_has_mode(file, mode)


### PR DESCRIPTION
This change will allow to use numeric `uid` and `gid` with the file's matchers `be_owned_by` and `be_grouped_into`.

``` ruby
describe file('/path/file') do
  it { should be_owned_by '1001' }
end
```

The `uid` or `gid` can be used as _String_ or _Numeric_.

``` ruby
describe file('/path/file') do
  it { should be_grouped_into 1002 }
end
```

This can be useful to test files or directories inside of Linux Container where the users doesn't have to correlate with the ones in the host.
