### PR TITLE
Port matcher matches port by a substring but not the whole number

### DIFF
--- a/lib/specinfra/command/base/port.rb
+++ b/lib/specinfra/command/base/port.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Base::Port < Specinfra::Command::Base
   class << self
     def check_is_listening(port, options={})
-      pattern = ":#{port}"
+      pattern = ":#{port} "
       pattern = " #{options[:local_address]}#{pattern}" if options[:local_address]
       pattern = "^#{options[:protocol]} .*#{pattern}" if options[:protocol]
       "netstat -tunl | grep -- #{escape(pattern)}"


### PR DESCRIPTION
The match expression for grep is not terminated now and that leads to errors when matching substrings.

For example:

```
describe port(77) do
  it { should be_listening }
end
```

This case would match ports 77, 777 and 777

The pull request should fix the issue.
I believe it should be compatible to all systems but It was tested only on Ubuntu 12.04
