### PR TITLE
fix brew get_version

### DIFF
--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -24,7 +24,7 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     end
 
     def get_version(package, opts=nil)
-      "basename $(/usr/local/bin/brew info #{package} | grep '\*$' | awk '{print $1}')"
+      "basename $((/usr/local/bin/brew info #{package} | grep '\*$' || /usr/local/bin/brew info #{package} | grep '^/usr/local/Cellar' | tail -1) | awk '{print $1}')"
     end
   end
 end


### PR DESCRIPTION
I tried to use ssh on OSX(for itamae). So I found a brew get version command is not working.

brew in `openssl` and`readline` There are things that `link` has not been recommended.
In the case of such a library `*` is not displayed.

```
$ brew info openssl
openssl: stable 1.0.1j (bottled)
https://openssl.org

(...snip...)

/usr/local/Cellar/openssl/1.0.1g (429 files, 15M)
  Poured from bottle
/usr/local/Cellar/openssl/1.0.1j (431 files, 15M)
  Poured from bottle
/usr/local/Cellar/openssl/1.0.1j_1 (431 files, 15M)
  Poured from bottle
(...snip...)
```

Current behavior looks like this.

``` ruby
$ bundle exec irb
irb(main):001:0> require 'specinfra'
=> true
irb(main):002:0> command = Specinfra.command.get(:get_package_version, 'openssl')
=> "basename $(/usr/local/bin/brew info openssl | grep '*$' | awk '{print $1}')"
irb(main):003:0> Specinfra.backend.run_command(command).stdout
=> "usage: basename string [suffix]\n       basename [-a] [-s suffix] string [...]\n"
```

This patch is `*` not found case use the last line of  `/usr/local/Celar`.

``` ruby
irb(main):001:0> require 'specinfra'
=> true
irb(main):002:0> command = Specinfra.command.get(:get_package_version, 'openssl')
=> "basename $((/usr/local/bin/brew info openssl | grep '*$' || /usr/local/bin/brew info openssl | grep '^/usr/local/Cellar' | tail -1) | awk '{print $1}')"
irb(main):003:0> Specinfra.backend.run_command(command).stdout
=> "1.0.1j_1\n"
```

Will work as before if is `*` displayed.

``` ruby
irb(main):004:0> command = Specinfra.command.get(:get_package_version, 'go')
=> "basename $((/usr/local/bin/brew info go | grep '*$' || /usr/local/bin/brew info go | grep '^/usr/local/Cellar' | tail -1) | awk '{print $1}')"
irb(main):005:0> Specinfra.backend.run_command(command).stdout
=> "1.4\n"
```
