### PR TITLE
Create send_directory backend command

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -25,6 +25,10 @@ module Specinfra::Backend
       FileUtils.cp(from, to)
     end
 
+    def send_directory(from, to)
+      FileUtils.cp_r(from, to)
+    end
+
     def build_command(cmd)
       shell = Specinfra.configuration.shell || '/bin/sh'
       cmd = cmd.shelljoin if cmd.is_a?(Array)

--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -24,14 +24,11 @@ module Specinfra::Backend
     end
 
     def send_file(from, to)
-      if Specinfra.configuration.scp.nil?
-        Specinfra.configuration.scp = create_scp
-      end
+      scp_upload!(from, to)
+    end
 
-      tmp = File.join('/tmp', File.basename(to))
-      scp = Specinfra.configuration.scp
-      scp.upload!(from, tmp)
-      run_command(Specinfra.command.get(:move_file, tmp, to))
+    def send_directory(from, to)
+      scp_upload!(from, to, :recursive => true)
     end
 
     def build_command(cmd)
@@ -84,7 +81,18 @@ module Specinfra::Backend
       end
       Net::SCP.new(ssh)
     end
-      
+
+    def scp_upload!(from, to, opt={})
+      if Specinfra.configuration.scp.nil?
+        Specinfra.configuration.scp = create_scp
+      end
+
+      tmp = File.join('/tmp', File.basename(to))
+      scp = Specinfra.configuration.scp
+      scp.upload!(from, tmp, opt)
+      run_command(Specinfra.command.get(:move_file, tmp, to))
+    end
+
     def ssh_exec!(command)
       stdout_data = ''
       stderr_data = ''


### PR DESCRIPTION
I'm creating [remote_directory resource](https://docs.chef.io/resource_remote_directory.html) on itamae [★](https://github.com/k0kubun/itamae/commit/87dfc32baa34a84d23fc4e9b9277e0f29076da84). But sending directory via `Net::SCP#scp_command` requires `:recursive` option [★](https://github.com/net-ssh/net-scp/blob/7677524617cc733b5ee0b15f090ed81a361e0600/lib/net/scp.rb#L335), so I couldn't send directory with `send_file`.

Thus I made send_directory backend API to send a directory.
