### PR TITLE
Add more non-interactive options to apt-get

### DIFF
--- a/lib/specinfra/command/debian/base/package.rb
+++ b/lib/specinfra/command/debian/base/package.rb
@@ -18,7 +18,7 @@ class Specinfra::Command::Debian::Base::Package < Specinfra::Command::Linux::Bas
       else
         full_package = package
       end
-      "DEBIAN_FRONTEND='noninteractive' apt-get -y #{option} install #{full_package}"
+      "DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' #{option} install #{full_package}"
     end
 
     def get_version(package, opts=nil)


### PR DESCRIPTION
Even when `DEBIAN_FRONTEND=noninteractive` and `-y` is given,
`apt-get install` requests user input on some cases.

```
$ sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y lxc-docker=1.4.1
Reading package lists... Done
Building dependency tree
Reading state information... Done
lxc-docker is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 76 not upgraded.
2 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Setting up lxc-docker-1.4.1 (1.4.1) ...

Configuration file '/etc/default/docker'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** docker (Y/I/N/O/D/Z) [default=N] ?
```
