### PR TITLE
Modify regex to skip commented 'start on' statements for upstart services

### DIFF
--- a/lib/specinfra/command/debian/base/service.rb
+++ b/lib/specinfra/command/debian/base/service.rb
@@ -2,7 +2,7 @@ class Specinfra::Command::Debian::Base::Service < Specinfra::Command::Linux::Bas
   class << self
     def check_is_enabled(service, level=3)
       # Until everything uses Upstart, this needs an OR.
-      "ls /etc/rc#{level}.d/ | grep -- '^S..#{escape(service)}$' || grep 'start on' /etc/init/#{escape(service)}.conf"
+      "ls /etc/rc#{level}.d/ | grep -- '^S..#{escape(service)}$' || grep '^\s*start on' /etc/init/#{escape(service)}.conf"
     end
 
     def enable(service)


### PR DESCRIPTION
Chef comments the 'start on' line when disabling upstart services. For example:
```
service 'rsyslog' do
  action :disable
end
```
... results in:
```
...
description	"system logging daemon"

#start on filesystem
stop on runlevel [06]
...
```

This change modifies the regex to only match lines that start with (some optional whitespace and) the 'start on' statement.