### PR TITLE
remove Set-ExecutionPolicy. no longer need on the appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,6 @@ cache:
 install:
   - git submodule update --init --recursive
   - ps: Enable-PSRemoting -Force
-  - ps: Set-ExecutionPolicy RemoteSigned
   - winrm quickconfig -q
   - winrm set winrm/config/client @{TrustedHosts="*"}
   - winrm set winrm/config/client/auth @{Basic="true"}


### PR DESCRIPTION
Appveyorで通らなくなっていたので、Set-ExecutionPolicy行を消しました。

ひと通り走るようになりました。
https://ci.appveyor.com/project/serverspec-windows-integration-test/specinfra
