### PR TITLE
rake task host_inventory should be recursive

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ if defined?(RSpec)
     end
 
     RSpec::Core::RakeTask.new(:host_inventory) do |t|
-      t.pattern = "spec/host_inventory/*_spec.rb"
+      t.pattern = "spec/host_inventory/**/*_spec.rb"
     end
   end
 end


### PR DESCRIPTION
I think _host_inventory_ rake job should be also recursive.

Before this change:
```
$ rake spec:host_inventory

Finished in 0.00057 seconds (files took 0.07158 seconds to load)
0 examples, 0 failures
```

After the change:
```
$ rake spec:host_inventory

Finished in 0.06071 seconds (files took 0.49513 seconds to load)
78 examples, 0 failures
```