### PR TITLE
Distinguish between IPv4 and IPv6 lookups

### DIFF
--- a/lib/specinfra/command/module/ss.rb
+++ b/lib/specinfra/command/module/ss.rb
@@ -24,10 +24,18 @@ module Specinfra
 
         def command_options(protocol)
           case protocol
-          when /\Atcp/
-            "-tnl"
+            when /\Atcp/
+              if protocol == 'tcp'
+                "-tnl4"
+              else
+                "-tnl6"
+              end
           when /\Audp/
-            "-unl"
+            if protocol == 'udp'
+              "-unl4"
+            else
+              "-unl6"
+            end
           else
             "-tunl"
           end

--- a/spec/command/module/ss_spec.rb
+++ b/spec/command/module/ss_spec.rb
@@ -5,13 +5,13 @@ describe Specinfra::Command::Module::Ss do
     extend Specinfra::Command::Module::Ss
   end
   let(:klass) { Specinfra::Command::Module::Ss::Test }
-  it { expect(klass.check_is_listening('80')).to eq 'ss -tunl | grep -- :80\ ' }
-  it { expect(klass.check_is_listening('80', options={:protocol => 'tcp'})).to eq 'ss -tnl | grep -- :80\ ' }
-  it { expect(klass.check_is_listening('80', options={:protocol => 'udp'})).to eq 'ss -unl | grep -- :80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl | grep -- \ \*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl | grep -- \ \*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl | grep -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl | grep -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp'})).to eq 'ss -unl | grep -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80')).to eq 'ss -tunl4 | grep -- :80\ ' }
+  it { expect(klass.check_is_listening('80', options={:protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- :80\ ' }
+  it { expect(klass.check_is_listening('80', options={:protocol => 'udp'})).to eq 'ss -unl4 | grep -- :80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl4 | grep -- \ \*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl4 | grep -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ 1.2.3.4:80\ ' }
 end

--- a/spec/command/module/ss_spec.rb
+++ b/spec/command/module/ss_spec.rb
@@ -5,13 +5,13 @@ describe Specinfra::Command::Module::Ss do
     extend Specinfra::Command::Module::Ss
   end
   let(:klass) { Specinfra::Command::Module::Ss::Test }
-  it { expect(klass.check_is_listening('80')).to eq 'ss -tunl4 | grep -- :80\ ' }
+  it { expect(klass.check_is_listening('80')).to eq 'ss -tunl | grep -- :80\ ' }
   it { expect(klass.check_is_listening('80', options={:protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- :80\ ' }
   it { expect(klass.check_is_listening('80', options={:protocol => 'udp'})).to eq 'ss -unl4 | grep -- :80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl4 | grep -- \ \*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \*:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \*:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \*:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl4 | grep -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl | grep -- \ 1.2.3.4:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ 1.2.3.4:80\ ' }
 end

--- a/spec/command/module/ss_spec.rb
+++ b/spec/command/module/ss_spec.rb
@@ -11,7 +11,7 @@ describe Specinfra::Command::Module::Ss do
   it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \*:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \*:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl4 | grep -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl | grep -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl | grep -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ 1.2.3.4:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ 1.2.3.4:80\ ' }
 end


### PR DESCRIPTION
Currently users which want to verify that ports are listening to `tcp6` or `udp6` connections are not able to steadily verify that as the output generated by the `ss` command in the codebase is the same for both `tcp/udp` and `tcp6/udp6`.

This PR should make a distinction and allow Serverspec tests like:
```
describe port(80) do
  it { should_not be_listening.with('tcp6') }
  it { should_not be_listening.with('udp6') }
end
```
to pass when such capabilities are disabled (like when managed through `sysctl`, etc).