### PR TITLE
interface: Ensure same results for *bsd as for linux

### DIFF
--- a/lib/specinfra/command/freebsd/base/interface.rb
+++ b/lib/specinfra/command/freebsd/base/interface.rb
@@ -5,11 +5,31 @@ class Specinfra::Command::Freebsd::Base::Interface < Specinfra::Command::Base::I
     end
 
     def check_has_ipv4_address(interface, ip_address)
-      "ifconfig #{interface} | grep -w inet | cut -d ' ' -f 2"
+      ip_address = ip_address.dup
+      if ip_address =~ /\/\d+$/
+        # remove the prefix - better would be to calculate the netmask
+        ip_address.gsub!(/\/\d+$/, "") 
+      end
+      ip_address << " "
+      ip_address.gsub!(".", "\\.")
+      "ifconfig #{interface} inet | grep 'inet #{ip_address}'"
     end
 
     def check_has_ipv6_address(interface, ip_address)
-      "ifconfig #{interface} | grep -w inet6 | cut -d ' ' -f 2"
+      ip_address = ip_address.dup
+      (ip_address, prefixlen) = ip_address.split(/\//)
+      ip_address.downcase!
+      if ip_address =~ /^fe80::/i
+        # link local needs the scope (interface) appended 
+        ip_address << "%#{interface}"
+      end 
+      unless prefixlen.to_s.empty? 
+        # append prefixlen 
+        ip_address << " prefixlen #{prefixlen}"
+      else 
+        ip_address << " "
+      end
+      "ifconfig #{interface} inet6 | grep 'inet6 #{ip_address}'"
     end
   end
 end

--- a/lib/specinfra/command/linux/base/interface.rb
+++ b/lib/specinfra/command/linux/base/interface.rb
@@ -16,7 +16,7 @@ class Specinfra::Command::Linux::Base::Interface < Specinfra::Command::Base::Int
         ip_address << "/"
       end
       ip_address.gsub!(".", "\\.")
-      "ip addr show #{interface} | grep 'inet #{ip_address}'"
+      "ip -4 addr show #{interface} | grep 'inet #{ip_address}'"
     end
 
     def check_has_ipv6_address(interface, ip_address)
@@ -27,7 +27,7 @@ class Specinfra::Command::Linux::Base::Interface < Specinfra::Command::Base::Int
         ip_address << "/"
       end
       ip_address.downcase!
-      "ip addr show #{interface} | grep 'inet6 #{ip_address}'"
+      "ip -6 addr show #{interface} | grep 'inet6 #{ip_address}'"
     end
 
     def get_link_state(name)

--- a/lib/specinfra/command/openbsd/base/interface.rb
+++ b/lib/specinfra/command/openbsd/base/interface.rb
@@ -9,11 +9,32 @@ class Specinfra::Command::Openbsd::Base::Interface < Specinfra::Command::Base::I
     end
 
     def check_has_ipv4_address(interface, ip_address)
-      "ifconfig #{interface} | grep -w inet | cut -d ' ' -f 2"
+      ip_address = ip_address.dup
+      if ip_address =~ /\/\d+$/
+        # remove the prefix - better would be to calculate the netmask
+        ip_address.gsub!(/\/\d+$/, "") 
+      end
+      ip_address << " "
+      ip_address.gsub!(".", "\\.")
+      "ifconfig #{interface} inet | grep 'inet #{ip_address}'"
     end
 
     def check_has_ipv6_address(interface, ip_address)
-      "ifconfig #{interface} | grep -w inet6 | cut -d ' ' -f 2"
+      ip_address = ip_address.dup
+      (ip_address, prefixlen) = ip_address.split(/\//)
+      ip_address.downcase!
+      if ip_address =~ /^fe80::/i
+        # link local needs the scope (interface) appended 
+        ip_address << "%#{interface}"
+      end 
+      unless prefixlen.to_s.empty? 
+        # append prefixlen 
+        ip_address << " prefixlen #{prefixlen}"
+      else 
+        ip_address << " "
+      end
+      "ifconfig #{interface} inet6 | grep 'inet6 #{ip_address}'"
     end
+
   end
 end

--- a/spec/command/freebsd/interface_spec.rb
+++ b/spec/command/freebsd/interface_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'freebsd'
+
+describe get_command(:check_interface_has_ipv6_address, 'vtnet0', '2001:0db8:bd05:01d2:288a:1fc0:0001:10ee') do
+  it { should eq "ifconfig vtnet0 inet6 | grep 'inet6 2001:0db8:bd05:01d2:288a:1fc0:0001:10ee '" }
+end
+
+describe get_command(:check_interface_has_ipv6_address, 'vtnet0', '2001:0db8:bd05:01d2:288a:1fc0:0001:10ee/64') do
+  it { should eq "ifconfig vtnet0 inet6 | grep 'inet6 2001:0db8:bd05:01d2:288a:1fc0:0001:10ee prefixlen 64'" }
+end
+
+describe get_command(:check_interface_has_ipv6_address, 'vtnet0', 'fe80::5054:ff:fe01:10ee/64') do
+  it { should eq "ifconfig vtnet0 inet6 | grep 'inet6 fe80::5054:ff:fe01:10ee%vtnet0 prefixlen 64'" }
+end
+
+describe get_command(:check_interface_has_ipv6_address, 'vtnet0', 'fe80::5054:ff:fe01:10ee') do
+  it { should eq "ifconfig vtnet0 inet6 | grep 'inet6 fe80::5054:ff:fe01:10ee%vtnet0 '" }
+end
+
+describe get_command(:check_interface_has_ipv4_address, 'vtnet0', '192.168.0.123') do
+  it { should eq "ifconfig vtnet0 inet | grep 'inet 192\\.168\\.0\\.123 '" }
+end
+
+describe get_command(:check_interface_has_ipv4_address, 'vtnet0', '192.168.0.123/24') do
+  it { should eq "ifconfig vtnet0 inet | grep 'inet 192\\.168\\.0\\.123 '" }
+end

--- a/spec/command/linux/interface_spec.rb
+++ b/spec/command/linux/interface_spec.rb
@@ -4,7 +4,19 @@ property[:os] = nil
 set :os, :family => 'linux'
 
 describe get_command(:check_interface_has_ipv6_address, 'eth0', '2001:0db8:bd05:01d2:288a:1fc0:0001:10ee') do
-  it { should eq "ip addr show eth0 | grep 'inet6 2001:0db8:bd05:01d2:288a:1fc0:0001:10ee/'" }
+  it { should eq "ip -6 addr show eth0 | grep 'inet6 2001:0db8:bd05:01d2:288a:1fc0:0001:10ee/'" }
+end
+
+describe get_command(:check_interface_has_ipv6_address, 'eth0', '2001:0db8:bd05:01d2:288a:1fc0:0001:10ee/64') do
+  it { should eq "ip -6 addr show eth0 | grep 'inet6 2001:0db8:bd05:01d2:288a:1fc0:0001:10ee/64 '" }
+end
+
+describe get_command(:check_interface_has_ipv4_address, 'eth0', '192.168.0.123') do
+  it { should eq "ip -4 addr show eth0 | grep 'inet 192\\.168\\.0\\.123/'" }
+end
+
+describe get_command(:check_interface_has_ipv4_address, 'eth0', '192.168.0.123/24') do
+  it { should eq "ip -4 addr show eth0 | grep 'inet 192\\.168\\.0\\.123/24 '" }
 end
 
 describe get_command(:get_interface_link_state, 'eth0') do

--- a/spec/command/openbsd/interface_spec.rb
+++ b/spec/command/openbsd/interface_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'openbsd'
+
+describe get_command(:check_interface_has_ipv6_address, 'vio0', '2001:0db8:bd05:01d2:288a:1fc0:0001:10ee') do
+  it { should eq "ifconfig vio0 inet6 | grep 'inet6 2001:0db8:bd05:01d2:288a:1fc0:0001:10ee '" }
+end
+
+describe get_command(:check_interface_has_ipv6_address, 'vio0', '2001:0db8:bd05:01d2:288a:1fc0:0001:10ee/64') do
+  it { should eq "ifconfig vio0 inet6 | grep 'inet6 2001:0db8:bd05:01d2:288a:1fc0:0001:10ee prefixlen 64'" }
+end
+
+describe get_command(:check_interface_has_ipv6_address, 'vio0', 'fe80::5054:ff:fe01:10ee/64') do
+  it { should eq "ifconfig vio0 inet6 | grep 'inet6 fe80::5054:ff:fe01:10ee%vio0 prefixlen 64'" }
+end
+
+describe get_command(:check_interface_has_ipv6_address, 'vio0', 'fe80::5054:ff:fe01:10ee') do
+  it { should eq "ifconfig vio0 inet6 | grep 'inet6 fe80::5054:ff:fe01:10ee%vio0 '" }
+end
+
+describe get_command(:check_interface_has_ipv4_address, 'vio0', '192.168.0.123') do
+  it { should eq "ifconfig vio0 inet | grep 'inet 192\\.168\\.0\\.123 '" }
+end
+
+describe get_command(:check_interface_has_ipv4_address, 'vio0', '192.168.0.123/24') do
+  it { should eq "ifconfig vio0 inet | grep 'inet 192\\.168\\.0\\.123 '" }
+end


### PR DESCRIPTION
The interface code for the freebsd and openbsd was slightly out of touch with the already existing linux one. Adjusted it to work the same way.
Unit tests for freebsd and openbsd are included. Plus expanded the linux ones.
Note: I think a construct like 'its(:ipv6_address) { should match /fe80::/ }' for the interface is more flexible, I'll probably add it in the near future.