### PR TITLE
Fixed check_is_running is not work for postgresql-9.3 on Ubuntu 14.04.3

### DIFF
--- a/lib/specinfra/command/ubuntu/base/service.rb
+++ b/lib/specinfra/command/ubuntu/base/service.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Ubuntu::Base::Service < Specinfra::Command::Debian::Base::Service
   class << self
     def check_is_running(service)
-      "service #{escape(service)} status && service #{escape(service)} status | grep 'running'"
+      "service #{escape(service)} status && service #{escape(service)} status | egrep 'running|online'"
     end
   end
 end


### PR DESCRIPTION
Because, `service postgresql status` not return "running"

~~~
$ sudo service postgresql status
9.3/main (port 5432): online
~~~