### PR TITLE
Fix OpenBSD service checks

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -243,6 +243,10 @@ require 'specinfra/command/openbsd/base/routing_table'
 require 'specinfra/command/openbsd/base/service'
 require 'specinfra/command/openbsd/base/user'
 
+# OpenBSD >= V5.7 (inherit OpenBSD)
+require 'specinfra/command/openbsd/v57'
+require 'specinfra/command/openbsd/v57/service'
+
 # Solaris (inherit Base)
 require 'specinfra/command/solaris'
 require 'specinfra/command/solaris/base'

--- a/lib/specinfra/command/openbsd/base/service.rb
+++ b/lib/specinfra/command/openbsd/base/service.rb
@@ -1,5 +1,13 @@
 class Specinfra::Command::Openbsd::Base::Service < Specinfra::Command::Base::Service
   class << self
+    def create
+      if os[:release].to_f < 5.7
+        self
+      else
+        Specinfra::Command::Openbsd::V57::Service
+      end
+    end
+
     def check_is_enabled(service, level=nil)
       "/etc/rc.d/#{escape(service)} status"
     end

--- a/lib/specinfra/command/openbsd/v57.rb
+++ b/lib/specinfra/command/openbsd/v57.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Openbsd::V57 < Specinfra::Command::Openbsd::Base
+end

--- a/lib/specinfra/command/openbsd/v57/service.rb
+++ b/lib/specinfra/command/openbsd/v57/service.rb
@@ -1,0 +1,35 @@
+class Specinfra::Command::Openbsd::V57::Service < Specinfra::Command::Openbsd::Base::Service
+  class << self
+    def check_is_enabled(service, level=nil)
+      "rcctl get #{escape(service)} status"
+    end
+
+    def check_is_running(service)
+      "rcctl check #{escape(service)}"
+    end
+
+    def enable(service)
+      "rcctl set #{escape(service)} status on"
+    end
+
+    def disable(service)
+      "rcctl set #{escape(service)} status off"
+    end
+
+    def start(service)
+      "rcctl start #{escape(service)}"
+    end
+
+    def stop(service)
+      "rcctl stop #{escape(service)}"
+    end
+
+    def restart(service)
+      "rcctl restart #{escape(service)}"
+    end
+
+    def reload(service)
+      "rcctl reload #{escape(service)}"
+    end
+  end
+end

--- a/spec/command/openbsd/service_spec.rb
+++ b/spec/command/openbsd/service_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'openbsd'
+
+describe get_command(:check_service_is_enabled, 'httpd') do
+  it { should eq '/etc/rc.d/httpd status' }
+end
+
+describe get_command(:check_service_is_running, 'httpd') do
+  it { should eq '/etc/rc.d/httpd check' }
+end

--- a/spec/command/openbsd57/service_spec.rb
+++ b/spec/command/openbsd57/service_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'openbsd', :release => '5.7'
+
+describe get_command(:check_service_is_enabled, 'httpd') do
+  it { should eq 'rcctl get httpd status' }
+end
+
+describe get_command(:check_service_is_running, 'httpd') do
+  it { should eq 'rcctl check httpd' }
+end
+
+describe get_command(:enable_service, 'httpd') do
+  it { should eq 'rcctl set httpd status on' }
+end
+
+describe get_command(:disable_service, 'httpd') do
+  it { should eq 'rcctl set httpd status off' }
+end
+
+describe get_command(:start_service, 'httpd') do
+  it { should eq 'rcctl start httpd' }
+end
+
+describe get_command(:stop_service, 'httpd') do
+  it { should eq 'rcctl stop httpd' }
+end
+
+describe get_command(:restart_service, 'httpd') do
+  it { should eq 'rcctl restart httpd' }
+end
+
+describe get_command(:reload_service, 'httpd') do
+  it { should eq 'rcctl reload httpd' }
+end


### PR DESCRIPTION
This puts back the change that 159b463a reverted to use `rcctl` as the enabled check didn't work at all for any service I've tried on 5.7. However the invocation should be `rcctl get foo status` rather than `rcctl status foo`.