### PR TITLE
ubuntu/ppa: Allow quotes

### DIFF
--- a/lib/specinfra/command/ubuntu/base/ppa.rb
+++ b/lib/specinfra/command/ubuntu/base/ppa.rb
@@ -1,11 +1,11 @@
 class Specinfra::Command::Ubuntu::Base::Ppa < Specinfra::Command::Debian::Base::Ppa
   class << self
     def check_exists(package)
-      %Q{find /etc/apt/ -name \*.list | xargs grep -o -E "deb +http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
+      %Q{find /etc/apt/ -name \*.list | xargs grep -o -E "deb +[\"']?http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
     end
 
     def check_is_enabled(package)
-      %Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
+      %Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\"']?http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
     end
 
     private

--- a/spec/command/ubuntu/ppa_spec.rb
+++ b/spec/command/ubuntu/ppa_spec.rb
@@ -4,9 +4,9 @@ property[:os] = nil
 set :os, :family => 'ubuntu'
 
 describe get_command(:check_ppa_exists, 'nginx/stable') do
-  it { should eq 'find /etc/apt/ -name *.list | xargs grep -o -E "deb +http://ppa.launchpad.net/nginx/stable"' }
+  it { should eq %(find /etc/apt/ -name *.list | xargs grep -o -E "deb +["']?http://ppa.launchpad.net/nginx/stable") }
 end
 
 describe get_command(:check_ppa_is_enabled, 'nginx/stable') do
-  it { should eq 'find /etc/apt/ -name *.list | xargs grep -o -E "^deb +http://ppa.launchpad.net/nginx/stable"' }
+  it { should eq %(find /etc/apt/ -name *.list | xargs grep -o -E "^deb +["']?http://ppa.launchpad.net/nginx/stable") }
 end


### PR DESCRIPTION
opscode-cookbooks/apt surrounds PPA URLs with quotes (https://github.com/opscode-cookbooks/apt/blob/master/providers/repository.rb#L121). This adds an optional quote to the regex so that a PPA  added by said cookbook will pass the test.