### PR TITLE
Fix quote escaping for Ubuntu PPA regex

### DIFF
--- a/lib/specinfra/command/ubuntu/base/ppa.rb
+++ b/lib/specinfra/command/ubuntu/base/ppa.rb
@@ -1,11 +1,11 @@
 class Specinfra::Command::Ubuntu::Base::Ppa < Specinfra::Command::Debian::Base::Ppa
   class << self
     def check_exists(package)
-      %Q{find /etc/apt/ -name \*.list | xargs grep -o -E "deb +[\"']?http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
+      %Q{find /etc/apt/ -name \*.list | xargs grep -o -E "deb +[\\"']?http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
     end
 
     def check_is_enabled(package)
-      %Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\"']?http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
+      %Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\\"']?http://ppa.launchpad.net/#{to_apt_line_uri(package)}"}
     end
 
     private

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -12,6 +12,10 @@ describe Specinfra::Backend::Exec do
       it 'should escape special chars' do
         expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq '/bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)'
       end
+
+      it 'should escape quotes' do
+        expect(Specinfra.backend.build_command(%Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\\"']?http://ppa.launchpad.net/gluster/glusterfs-3.7"})).to eq('/bin/sh -c find\ /etc/apt/\ -name\ \*.list\ \|\ xargs\ grep\ -o\ -E\ \"\^deb\ \+\[\\\\\"\\\'\]\?http://ppa.launchpad.net/gluster/glusterfs-3.7\"')
+      end
     end
 
     context 'with custom shell' do

--- a/spec/command/ubuntu/ppa_spec.rb
+++ b/spec/command/ubuntu/ppa_spec.rb
@@ -4,9 +4,9 @@ property[:os] = nil
 set :os, :family => 'ubuntu'
 
 describe get_command(:check_ppa_exists, 'nginx/stable') do
-  it { should eq %(find /etc/apt/ -name *.list | xargs grep -o -E "deb +["']?http://ppa.launchpad.net/nginx/stable") }
+  it { should eq %(find /etc/apt/ -name *.list | xargs grep -o -E "deb +[\\\"']?http://ppa.launchpad.net/nginx/stable") }
 end
 
 describe get_command(:check_ppa_is_enabled, 'nginx/stable') do
-  it { should eq %(find /etc/apt/ -name *.list | xargs grep -o -E "^deb +["']?http://ppa.launchpad.net/nginx/stable") }
+  it { should eq %(find /etc/apt/ -name *.list | xargs grep -o -E "^deb +[\\\"']?http://ppa.launchpad.net/nginx/stable") }
 end


### PR DESCRIPTION
This fixes mizzy/specinfra#466. The backslashes and quotes were causing escaping issues.