### PR TITLE
host: Adding the +search to dig if a non-fqdn is passed to it.

### DIFF
--- a/lib/specinfra/command/darwin/base/host.rb
+++ b/lib/specinfra/command/darwin/base/host.rb
@@ -3,7 +3,7 @@ class Specinfra::Command::Darwin::Base::Host < Specinfra::Command::Base::Host
     def check_is_resolvable(name, type)
       if type == "dns"
         ## try to resolve either A or AAAA record; grep is used to return the appropriate exit code
-        %Q{dig +short +time=1 -q #{escape(name)} a #{escape(name)} aaaa | grep -qie '^[0-9a-f:.]*$'}
+        %Q{dig +search +short +time=1 -q #{escape(name)} a #{escape(name)} aaaa | grep -qie '^[0-9a-f:.]*$'}
       elsif type == "hosts"
         "sed 's/#.*$//' /etc/hosts | grep -w -- #{escape(name)}"
       else

--- a/spec/command/darwin/host_spec.rb
+++ b/spec/command/darwin/host_spec.rb
@@ -4,7 +4,7 @@ property[:os] = nil
 set :os, :family => 'darwin'
 
 describe get_command(:check_host_is_resolvable, 'pink.unicorn.com', 'dns') do 
-  it { should eq "dig +short +time=1 -q pink.unicorn.com a pink.unicorn.com aaaa | grep -qie '^[0-9a-f:.]*$'" } 
+  it { should eq "dig +search +short +time=1 -q pink.unicorn.com a pink.unicorn.com aaaa | grep -qie '^[0-9a-f:.]*$'" } 
 end
 
 describe get_command(:check_host_is_resolvable, 'pink.unicorn.com', 'hosts') do 


### PR DESCRIPTION
This is a small fix to dig command. This ensures dig behaves exactly like nslookup and is considering the /etc/resolv.conf's domain or search lines.