### PR TITLE
Don't try to use the -C switch for ps in OS X

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -148,6 +148,7 @@ require 'specinfra/command/darwin/base/inventory'
 require 'specinfra/command/darwin/base/service'
 require 'specinfra/command/darwin/base/package'
 require 'specinfra/command/darwin/base/port'
+require 'specinfra/command/darwin/base/process'
 require 'specinfra/command/darwin/base/user'
 
 # Debian (inherit Linux)

--- a/lib/specinfra/command/darwin/base/process.rb
+++ b/lib/specinfra/command/darwin/base/process.rb
@@ -1,0 +1,7 @@
+class Specinfra::Command::Darwin::Base::Process < Specinfra::Command::Base::Process
+  class << self
+    def get(process, opts)
+      "ps -A -c -o #{opts[:format]},command | grep -E -m 1 ^\\ *[0-9]+\\ +#{escape(process)}$ | awk '{print $1}'"
+    end
+  end
+end

--- a/spec/command/darwin/process_spec.rb
+++ b/spec/command/darwin/process_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+set :os, { :family => 'darwin' }
+
+describe get_command(:get_process, 'Google Chrome', :format => 'pid=') do
+  it { should eq "ps -A -c -o pid=,command | grep -E -m 1 ^\\ *[0-9]+\\ +Google\\ Chrome$ | awk '{print $1}'" }
+end


### PR DESCRIPTION
The -C switch in the BSD-flavored version of `ps` in OS X doesn't do
what it does in Linux:

```
-C      Change the way the CPU percentage is calculated by using a
        ``raw'' CPU calculation that ignores ``resident'' time (this normally
        has no effect).
```

```
$ ps -C Google\ Chrome -o pid= | head -1
ps: illegal argument: Google Chrome
```

This causes tests for `process('AppName')` resources to fail. This workaround
does get ugly, but yields the expected output:

```
$ ps -A -c -o command | grep Google\ Chrome
Google Chrome
Google Chrome Helper
Google Chrome Helper
```

```
$ ps -A -c -o pid=,command | grep -E -m 1 ^\ *[0-9]+\ +Google\ Chrome$
99159 Google Chrome
```

```
$ ps -A -c -o pid=,command | grep -E -m 1 ^\ *[0-9]+\ +Google\ Chrome$ | \
    awk '{print $1}'
99159
```