### PR TITLE
Fix check_file_is_linked_to

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -118,7 +118,7 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
     end
 
     def check_is_linked_to(link, target)
-      "stat -c %N #{escape(link)} | egrep -e \"-> .#{escape(target)}.\""
+      %Q|test x"$(readlink #{escape(link)})" = x"#{escape(target)}"|
     end
 
     def check_is_link(link)


### PR DESCRIPTION
Previously, `check_is_linked_to('hoge', 'foo')` returns true wrongly
when "hoge" is linked to "foobar", "foobaz", etc.