### PR TITLE
Let us know on which host our sudo password is incorrect.

### DIFF
--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -121,7 +121,7 @@ module Specinfra
             abort "FAILED: couldn't execute command (ssh.channel.exec)" if !success
             channel.on_data do |ch, data|
               if data.match retry_prompt
-                abort 'Wrong sudo password! Please confirm your password.'
+                abort "Wrong sudo password! Please confirm your password on #{get_config(:host)}."
               elsif data.match /^#{prompt}/
                 channel.send_data "#{get_config(:sudo_password)}\n"
               else


### PR DESCRIPTION
When running against a bunch of hosts where some of the hosts have some other password for you can be frustrating.  I thought it might be useful for the error message to tell you which host it was on, at least.