### PR TITLE
Collect block device of host inventory

### DIFF
--- a/lib/specinfra/command/linux/base/inventory.rb
+++ b/lib/specinfra/command/linux/base/inventory.rb
@@ -27,5 +27,10 @@ class Specinfra::Command::Linux::Base::Inventory < Specinfra::Command::Base::Inv
     def get_kernel
       'uname -s -r'
     end
+
+    def get_block_device
+      block_device_dirs = '/sys/block/*/{size,removable,device/{model,rev,state,timeout,vendor},queue/rotational}'
+      "for f in $(ls #{block_device_dirs}); do echo -e \"${f}\t$(cat ${f})\"; done"
+    end
   end
 end

--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -12,6 +12,7 @@ module Specinfra
       cpu
       virtualization
       kernel
+      block_device
     }
 
     include Enumerable

--- a/lib/specinfra/host_inventory/block_device.rb
+++ b/lib/specinfra/host_inventory/block_device.rb
@@ -1,0 +1,35 @@
+module Specinfra
+  class HostInventory
+    class BlockDevice < Base
+      # examples:
+      #   /sys/block/sda/size	10000
+      #   /sys/block/sr0/device/model	CD-ROM
+      BLOCK_DEVICE_REGEX = %r|\A/sys/block/(\w+)/(\w+)(?:/(\w+))?\t(.+)\z|
+
+      def get
+        cmd = backend.command.get(:get_inventory_block_device)
+        ret = backend.run_command(cmd)
+        if ret.exit_status == 0
+          parse(ret.stdout)
+        else
+          nil
+        end
+      end
+      def parse(ret)
+        block_device = {}
+        ret.each_line do |line|
+          line.strip!
+          if m = line.match(BLOCK_DEVICE_REGEX)
+            device = m[1].to_s
+            check = m[3].nil? ? m[2].to_s : m[3].to_s
+            value = m[4].to_s
+
+            block_device[device] = {} if block_device[device].nil?
+            block_device[device][check] = value
+          end
+        end
+        block_device
+      end
+    end
+  end
+end

--- a/spec/command/linux/inventory_spec.rb
+++ b/spec/command/linux/inventory_spec.rb
@@ -13,3 +13,8 @@ end
 describe get_command(:get_inventory_kernel) do
   it { should eq 'uname -s -r' }
 end
+
+describe get_command(:get_inventory_block_device) do
+  block_device_dirs = '/sys/block/*/{size,removable,device/{model,rev,state,timeout,vendor},queue/rotational}'
+  it { should eq "for f in $(ls #{block_device_dirs}); do echo -e \"${f}\t$(cat ${f})\"; done" }
+end

--- a/spec/host_inventory/linux/block_device_spec.rb
+++ b/spec/host_inventory/linux/block_device_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+## Output from:
+#
+# for f in $(ls /sys/block/*/{size,removable,device/{model,rev,state,timeout,vendor},queue/rotational}); do
+#     echo -e "${f}\t$(cat ${f})"
+# done
+str = <<-EOH
+/sys/block/loop0/queue/rotational	1
+/sys/block/loop0/removable	0
+/sys/block/loop0/size	0
+/sys/block/sda/device/model	HARDDISK
+/sys/block/sda/device/rev	1.0
+/sys/block/sda/device/state	running
+/sys/block/sda/device/timeout	30
+/sys/block/sda/device/vendor	ATA
+/sys/block/sda/queue/rotational	1
+/sys/block/sda/removable	0
+/sys/block/sda/size	40960000
+EOH
+
+describe Specinfra::HostInventory::BlockDevice do
+  let(:host_inventory) { nil }
+  describe 'Example of CentOS 6.6 Kernel version 2.6.32-504.23.4.el6.i686' do
+    ret = Specinfra::HostInventory::BlockDevice.new(host_inventory).parse(str)
+    example "/sys/block/loop0" do
+      expect(ret["loop0"]).to include(
+        "rotational" => "1",
+        "removable"  => "0",
+        "size"       => "0"
+      )
+    end
+    example "/sys/block/sda" do
+      expect(ret["sda"]).to include(
+        "model"      => "HARDDISK",
+        "rev"        => "1.0",
+        "state"      => "running",
+        "timeout"    => "30",
+        "vendor"     => "ATA",
+        "rotational" => "1",
+        "removable"  => "0",
+        "size"       => "40960000"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Like ohai, `block_device` collects data of `/sys/block/<dev>`.

This inventory stores the same result as [`block_device` of Ohai v8.6.0](https://github.com/chef/ohai/blob/v8.6.0/lib/ohai/plugins/linux/block_device.rb).