### PR TITLE
use `pkg info -e`

### DIFF
--- a/lib/specinfra/command/freebsd/v10/package.rb
+++ b/lib/specinfra/command/freebsd/v10/package.rb
@@ -4,7 +4,7 @@ class Specinfra::Command::Freebsd::V10::Package < Specinfra::Command::Freebsd::B
       if version
         "pkg query %v #{escape(package)} | grep -- #{escape(version)}"
       else
-        "pkg info #{escape(package)}"
+        "pkg info -e #{escape(package)}"
       end
     end
 


### PR DESCRIPTION
pkg info -e return 0 or 1: suitable for this use.
https://www.freebsd.org/cgi/man.cgi?query=pkg-info&apropos=0&sektion=0&manpath=FreeBSD+10.2-RELEASE&arch=default&format=html