### PR TITLE
Pass os_info to command_class.create

### DIFF
--- a/lib/specinfra/command/fedora/base/service.rb
+++ b/lib/specinfra/command/fedora/base/service.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Fedora::Base::Service < Specinfra::Command::Redhat::Base::Service
   class << self
-    def create
-      if os[:release].to_i < 15
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_i < 15
         self
       else
         Specinfra::Command::Fedora::V15::Service

--- a/lib/specinfra/command/freebsd/base/user.rb
+++ b/lib/specinfra/command/freebsd/base/user.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Freebsd::Base::User < Specinfra::Command::Base::User
   class << self
-    def create
-      if os[:release].to_i < 7
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_i < 7
         Specinfra::Command::Freebsd::V6::User
       else
         self

--- a/lib/specinfra/command/openbsd/base/service.rb
+++ b/lib/specinfra/command/openbsd/base/service.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Openbsd::Base::Service < Specinfra::Command::Base::Service
   class << self
-    def create
-      if os[:release].to_f < 5.7
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_f < 5.7
         self
       else
         Specinfra::Command::Openbsd::V57::Service

--- a/lib/specinfra/command_factory.rb
+++ b/lib/specinfra/command_factory.rb
@@ -51,7 +51,11 @@ class Specinfra::CommandFactory
       command_class = base_class.const_get(resource_type.to_camel_case)
     end
 
-    command_class.create
+    begin
+      command_class.create(@os_info)
+    rescue ArgumentError
+      command_class.create
+    end
   end
 
   def breakdown(meth)


### PR DESCRIPTION
Some commands see `os` (lib/specinfra/helper/os.rb) on creation,
which referes Specinfra.configuration.os or Specinfra.configuration.backend.
But it doesn't work on multiple backends (examples/multiple_backends.rb)
or Serverkit.