### PR TITLE
Check localhost for listening ports on Windows.

### DIFF
--- a/lib/specinfra/backend/powershell/support/is_port_listening.ps1
+++ b/lib/specinfra/backend/powershell/support/is_port_listening.ps1
@@ -4,6 +4,7 @@ function IsPortListening
   $netstatOutput = netstat -an | Out-String
   $networkIPs = (Get-WmiObject Win32_NetworkAdapterConfiguration | ? {$_.IPEnabled}) | %{ $_.IPAddress[0] }
   [array] $networkIPs += "0.0.0.0"
+  [array] $networkIPs += "127.0.0.1"
   foreach ($ipaddress in $networkIPs)
   {
     $matchExpression = ("$ipaddress" + ":" + $portNumber)


### PR DESCRIPTION
Specinfra doesn't detect ports that are listening on localhost on Windows, because no adapter lists 127.0.0.1 as one of its active addresses. This manually adds it to the list of addresses to check.