### PR TITLE
Allow forward slashes within PS literal

### DIFF
--- a/lib/specinfra/backend/powershell/command.rb
+++ b/lib/specinfra/backend/powershell/command.rb
@@ -22,7 +22,7 @@ module Specinfra
           when Regexp
             target.source
           else
-            target.to_s.gsub '/', ''
+            target.to_s.gsub '(^\/|\/$)', ''
           end
         end
 


### PR DESCRIPTION
The global substitution in the powershell command match is eating potentially useful forward slash characters.

Full detail at https://github.com/chef/chef-dk/issues/526