### PR TITLE
Support check_file_exists method on Windows

### DIFF
--- a/lib/specinfra/command/windows/base/file.rb
+++ b/lib/specinfra/command/windows/base/file.rb
@@ -1,5 +1,12 @@
 class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Base
   class << self
+    def check_exists(file)
+      cmd = %Q!Test-Path -Path "#{file}"!
+      Backend::PowerShell::Command.new do
+        exec cmd
+      end
+    end
+
     def check_is_file(file)
       cmd = item_has_attribute file, 'Archive'
       Backend::PowerShell::Command.new do


### PR DESCRIPTION
Specinfra didn't implement file exist check command on Windows.
So, add check_exists method.

before example: 
```
describe file("C:\\Windows") do
  it { should exist }
end
```
-->
```
~
  1) File "C:\Windows" should exist
     On host `localhost'
     Failure/Error: it { should exist }
     NotImplementedError:
       check_exists is not implemented in Specinfra::Command::Windows::Base::File
~
```

after example:
```
describe file("C:\\Windows") do
  it { should exist }
end
```
-->
```
~
File "C:\Windows"
  should exist
~
```