### PR TITLE
Added opts to execute run_command and docker_run!

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -28,7 +28,7 @@ module Specinfra
       def run_command(cmd, opts={})
         cmd = build_command(cmd)
         cmd = add_pre_command(cmd)
-        docker_run!(cmd)
+        docker_run!(cmd, opts)
       end
 
       def build_command(cmd)
@@ -87,7 +87,7 @@ module Specinfra
       end
 
       def docker_run!(cmd, opts={})
-        stdout, stderr, status = @container.exec(['/bin/sh', '-c', cmd])
+        stdout, stderr, status = @container.exec(['/bin/sh', '-c', cmd], opts)
 
         CommandResult.new :stdout => stdout.join, :stderr => stderr.join,
         :exit_status => status


### PR DESCRIPTION
I want to execute sudo with Specinfra::Backend::Docker#run_command.

```
require 'specinfra'
require 'docker'
Excon.defaults[:ssl_verify_peer] = false
@backend = Specinfra::Backend::Docker.new(docker_image:'centos:7')
@backend.run_command('yum install -y sudo')
@backend.run_command('sudo -H -u root -- /bin/sh -c cd /tmp/ && ls -l')
# => sudo: sorry, you must have a tty to run sudo
```

So I modified.

```
@backend.run_command('sudo -H -u root -- /bin/sh -c cd /tmp/ && ls -l', { tty: true })
```