### PR TITLE
mail_alias: Replacing the trailing $ (dollar) with \b (word boundry)

### DIFF
--- a/lib/specinfra/command/base/mail_alias.rb
+++ b/lib/specinfra/command/base/mail_alias.rb
@@ -1,8 +1,8 @@
 class Specinfra::Command::Base::MailAlias < Specinfra::Command::Base
   class << self
     def check_is_aliased_to(mail_alias, recipient)
-      recipient = "[[:space:]]([\"']?)#{recipient}\\1"
-      "getent aliases #{escape(mail_alias)} | egrep -- #{escape(recipient)}$"
+      recipient = "[[:space:]]([\"']?)#{recipient}\\1\\b"
+      "getent aliases #{escape(mail_alias)} | egrep -- #{escape(recipient)}"
     end
 
     def add(mail_alias, recipient)

--- a/spec/command/base/mail_alias.rb
+++ b/spec/command/base/mail_alias.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+set :os, { :family => nil }
+
+describe get_command(:check_mail_alias_is_aliased_to, 'pink', 'pony') do
+  it do 
+    should eq %Q{getent aliases pink | } +
+              %Q{egrep -- \\\[\\\[:space:\\\]\\\]\\\(\\\[\\\"\\'\\\]\\?\\)pony\\\\1\\\\b}
+  end 
+end


### PR DESCRIPTION
 Currently entries in the /etc/alias file that look like this

   myalias:     foo, bar, batz

 can only be parsed in the exact order:

   describe mail_alias('myalias') do
     it { should be_aliased_to('foo, bar, batz') }
   end

 If the order changes or more white space is added the whole thing falls apart.

 Replacing the $ with \b at the end of the egrep allows for more flexibilty:

   describe mail_alias('myalias') do
     it { should be_aliased_to('batz')
     it { should be_aliased_to('foo')
     it { should be_aliased_to('bar')
   end

  The order becomes irrelevant.

  This scheme has been tested against the following patterns:
    myalias:         foo, bar, batz
    myalias:         foo, bar, batz
    myalias:         foo , bar , batz
    myalias:         foo
    myalias:         /foo/bar, /bar/foo
    myalias:         "|/foo/bar", '|/bar/foo'
    myalias:         foo bar, batz, foo, bar