### PR TITLE
Fix a typo in the comment for Configuration#os

### DIFF
--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -29,7 +29,7 @@ module Specinfra
       end
 
       # Define os method explicitly to avoid stack level
-      # too deep caused by Helpet::DetectOS#os
+      # too deep caused by Helper::DetectOS#os
       def os(value=nil)
         @os = value if value
         if @os.nil? && defined?(RSpec) && RSpec.configuration.respond_to?(:os)


### PR DESCRIPTION
`Helpet::DetectOS#os` in the comment seems to be a typo of `Helper::DetectOS#os`.
I fixed it.