### PR TITLE
Supports Raspbian Jessie

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -163,6 +163,9 @@ require 'specinfra/command/debian/base/service'
 require 'specinfra/command/debian/v8'
 require 'specinfra/command/debian/v8/service'
 
+# Raspbian (inherit Debian)
+require 'specinfra/command/raspbian'
+
 # Ubuntu (inherit Debian)
 require 'specinfra/command/ubuntu'
 require 'specinfra/command/ubuntu/base'

--- a/lib/specinfra/command/raspbian.rb
+++ b/lib/specinfra/command/raspbian.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Raspbian < Specinfra::Command::Debian; end


### PR DESCRIPTION
A new class Specinfra::Command::Raspbian is now required for Raspbian Jessie (Linux distribution for Raspberry Pi compatible with Debian v8) because `lsb_release -ir` returns `Raspbian` as the Distributor ID.
Specinfra raises a `NameError: uninitialized constant Raspbian` without creating this class.