### PR TITLE
Include RPM release in package version

### DIFF
--- a/lib/specinfra/command/redhat/base/package.rb
+++ b/lib/specinfra/command/redhat/base/package.rb
@@ -11,7 +11,7 @@ class Specinfra::Command::Redhat::Base::Package < Specinfra::Command::Linux::Bas
     alias :check_is_installed_by_rpm :check_is_installed
 
     def get_version(package, opts=nil)
-      "rpm -qi #{package} | grep Version | awk '{print $3}'"
+      "rpm -q --qf '%{VERSION}-%{RELEASE}' #{package}"
     end
 
     def install(package, version=nil, option='')


### PR DESCRIPTION
In RedHat and its clone, not only a packaged software version but also a
package release number are used for checking newer package availability.

This changes RPM version to include a release number.

I don't know much about SUSE package's version policy so only fix RedHat one.