### PR TITLE
belong_to_group: support for group names with spaces

### DIFF
--- a/lib/specinfra/command/base/user.rb
+++ b/lib/specinfra/command/base/user.rb
@@ -5,7 +5,7 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
     end
 
     def check_belongs_to_group(user, group)
-      "id #{escape(user)} | awk '{print $3}' | grep -- #{escape(group)}"
+      "id #{escape(user)} | sed 's/ context=.*//g' |awk -F= '{print $4}' | grep -- #{escape(group)}"
     end
 
     def check_belongs_to_primary_group(user, group)


### PR DESCRIPTION
This PR adds support for group names with spaces, for example in an environment that used a Windows domain for authentication and authorization.

Example on a RHEL7 server:

```
[jfolmer@host06 infratests]$ id
uid=1616201105(jfolmer) gid=1616200513(domain users) groups=1616200513(domain users) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
```

Previously:

```
[jfolmer@host06 infratests]$ id |awk '{print $3}'
users)
[jfolmer@host06 infratests]$ 
```

Improved command:

```
[jfolmer@host06 infratests]$ id |sed 's/ context=.*//g' |awk -F= '{print $4}'
1616200513(domain users)
[jfolmer@host06 infratests]$ 
```