### PR TITLE
Update Cumulus Linux support files

### DIFF
--- a/lib/specinfra/command/cumulus.rb
+++ b/lib/specinfra/command/cumulus.rb
@@ -1,4 +1,4 @@
-class Specinfra::Command::Cumulusnetworks; end
+class Specinfra::Command::Cumuluslinux; end
 
 
 

--- a/lib/specinfra/command/cumulus.rb
+++ b/lib/specinfra/command/cumulus.rb
@@ -1,4 +1,5 @@
 class Specinfra::Command::Cumuluslinux; end
+class Specinfra::Command::Cumulusnetworks; end
 
 
 

--- a/lib/specinfra/command/cumulus/base.rb
+++ b/lib/specinfra/command/cumulus/base.rb
@@ -1,2 +1,2 @@
-class Specinfra::Command::Cumulusnetworks::Base < Specinfra::Command::Debian::Base
+class Specinfra::Command::Cumuluslinux::Base < Specinfra::Command::Debian::Base
 end

--- a/lib/specinfra/command/cumulus/base.rb
+++ b/lib/specinfra/command/cumulus/base.rb
@@ -1,2 +1,6 @@
 class Specinfra::Command::Cumuluslinux::Base < Specinfra::Command::Debian::Base
 end
+
+class Specinfra::Command::Cumulusnetworks::Base < Specinfra::Command::Cumuluslinux::Base
+end
+

--- a/lib/specinfra/command/cumulus/base/ppa.rb
+++ b/lib/specinfra/command/cumulus/base/ppa.rb
@@ -1,4 +1,4 @@
-class Specinfra::Command::Cumulusnetworks::Base::Ppa < Specinfra::Command::Debian::Base::Ppa
+class Specinfra::Command::Cumuluslinux::Base::Ppa < Specinfra::Command::Debian::Base::Ppa
   class << self
     def check_exists(package)
       %Q{find /etc/apt/ -name \*.list | xargs grep -o "deb +http://repo.cumulusnetworks.com/#{to_apt_line_uri(package)}"}

--- a/lib/specinfra/command/cumulus/base/ppa.rb
+++ b/lib/specinfra/command/cumulus/base/ppa.rb
@@ -15,3 +15,6 @@ class Specinfra::Command::Cumuluslinux::Base::Ppa < Specinfra::Command::Debian::
     end
   end
 end
+
+class Specinfra::Command::Cumulusnetworks::Base::Ppa < Specinfra::Command::Cumuluslinux::Base::Ppa
+end

--- a/lib/specinfra/command/cumulus/base/service.rb
+++ b/lib/specinfra/command/cumulus/base/service.rb
@@ -1,4 +1,4 @@
-class Specinfra::Command::Cumulusnetworks::Base::Service < Specinfra::Command::Debian::Base::Service
+class Specinfra::Command::Cumuluslinux::Base::Service < Specinfra::Command::Debian::Base::Service
   class << self
     def check_is_running(service)
       "service #{escape(service)} status && service #{escape(service)} status | grep 'running'"

--- a/lib/specinfra/command/cumulus/base/service.rb
+++ b/lib/specinfra/command/cumulus/base/service.rb
@@ -5,3 +5,6 @@ class Specinfra::Command::Cumuluslinux::Base::Service < Specinfra::Command::Debi
     end
   end
 end
+
+class Specinfra::Command::Cumulusnetworks::Base::Service < Specinfra::Command::Cumuluslinux::Base::Service
+end

--- a/spec/command/cumulus/ppa_cumuluslinux_spec.rb
+++ b/spec/command/cumulus/ppa_cumuluslinux_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'cumuluslinux'
+
+describe get_command(:check_ppa_exists, 'git') do
+  it { should eq 'find /etc/apt/ -name *.list | xargs grep -o "deb +http://repo.cumulusnetworks.com/git"' }
+end

--- a/spec/command/cumulus/ppa_cumulusnetworks_spec.rb
+++ b/spec/command/cumulus/ppa_cumulusnetworks_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'cumulusnetworks'
+
+describe get_command(:check_ppa_exists, 'git') do
+  it { should eq 'find /etc/apt/ -name *.list | xargs grep -o "deb +http://repo.cumulusnetworks.com/git"' }
+end


### PR DESCRIPTION
/etc/lsb-release on cumulus linux changed from "cumulus networks" to "cumulus linux" in a recent version. this ensures serverspec works with the latest release of Cumulus Linux.