### PR TITLE
Allow custom brew prefix

### DIFF
--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -3,9 +3,9 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     def check_is_installed(package, version=nil)
       escaped_package = escape(package)
       if version
-        cmd = "/usr/local/bin/brew info #{escaped_package} | grep -E '^\/usr\/local\/Cellar\/#{escaped_package}\/#{escape(version)}'"
+        cmd = %Q[brew info #{escaped_package} | grep -E "^$(brew --prefix)/Cellar/#{escaped_package}/#{escape(version)}"]
       else
-        cmd = "/usr/local/bin/brew list -1 | grep -E '^#{escaped_package}$'"
+        cmd = "brew list -1 | grep -E '^#{escaped_package}$'"
       end
       cmd
     end
@@ -15,9 +15,9 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     def check_is_installed_by_homebrew_cask(package, version=nil)
       escaped_package = escape(package)
       if version
-        cmd = "/usr/local/bin/brew cask info #{escaped_package} | grep -E '^\/opt\/homebrew-cask\/Caskroom\/#{escaped_package}\/#{escape(version)}'"
+        cmd = "brew cask info #{escaped_package} | grep -E '^/opt/homebrew-cask/Caskroom/#{escaped_package}/#{escape(version)}'"
       else
-        cmd = "/usr/local/bin/brew cask list -1 | grep -E '^#{escaped_package}$'"
+        cmd = "brew cask list -1 | grep -E '^#{escaped_package}$'"
       end
       cmd
     end
@@ -30,11 +30,11 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
 
     def install(package, version=nil, option='')
       # Homebrew doesn't support to install specific version.
-      cmd = "/usr/local/bin/brew install #{option} '#{package}'"
+      cmd = "brew install #{option} '#{package}'"
     end
 
     def get_version(package, opts=nil)
-      "basename $((/usr/local/bin/brew info #{package} | grep '\*$' || /usr/local/bin/brew info #{package} | grep '^/usr/local/Cellar' | tail -1) | awk '{print $1}')"
+      %Q[basename $((brew info #{package} | grep '\*$' || brew info #{package} | grep "^$(brew --prefix)/Cellar" | tail -1) | awk '{print $1}')]
     end
   end
 end

--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Package
   class << self
     def check_is_installed(package, version=nil)
-      escaped_package = escape(package)
+      escaped_package = escape(File.basename(package))
       if version
         cmd = %Q[brew info #{escaped_package} | grep -E "^$(brew --prefix)/Cellar/#{escaped_package}/#{escape(version)}"]
       else
@@ -13,7 +13,7 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     alias :check_is_installed_by_homebrew :check_is_installed
 
     def check_is_installed_by_homebrew_cask(package, version=nil)
-      escaped_package = escape(package)
+      escaped_package = escape(File.basename(package))
       if version
         cmd = "brew cask info #{escaped_package} | grep -E '^/opt/homebrew-cask/Caskroom/#{escaped_package}/#{escape(version)}'"
       else

--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -5,7 +5,7 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
       if version
         cmd = %Q[brew info #{escaped_package} | grep -E "^$(brew --prefix)/Cellar/#{escaped_package}/#{escape(version)}"]
       else
-        cmd = "brew list -1 | grep -E '^#{escaped_package}$'"
+        cmd = "#{brew_list} | grep -E '^#{escaped_package}$'"
       end
       cmd
     end
@@ -17,7 +17,7 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
       if version
         cmd = "brew cask info #{escaped_package} | grep -E '^/opt/homebrew-cask/Caskroom/#{escaped_package}/#{escape(version)}'"
       else
-        cmd = "brew cask list -1 | grep -E '^#{escaped_package}$'"
+        cmd = "#{brew_cask_list} | grep -E '^#{escaped_package}$'"
       end
       cmd
     end
@@ -34,7 +34,17 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     end
 
     def get_version(package, opts=nil)
-      %Q[basename $((brew info #{package} | grep '\*$' || brew info #{package} | grep "^$(brew --prefix)/Cellar" | tail -1) | awk '{print $1}')]
+      %Q[ls -1 "$(brew --prefix)/Cellar/#{package}/" | tail -1]
+    end
+
+    def brew_list
+      # Since `brew list` is slow, directly check Cellar directory
+      'ls -1 "$(brew --prefix)/Cellar/"'
+    end
+
+    def brew_cask_list
+      # Since `brew cask list` is slow, directly check Caskroom directory
+      "ls -1 /opt/homebrew-cask/Caskroom/"
     end
   end
 end


### PR DESCRIPTION
I fixed `Specinfra::Command::Darwin::Base::Package` to support:

- custom brew prefix
  - It can be non-"/usr/local" path and checked by only `brew --prefix`
- proper check for "user/repo/formula" style installation
  - If `foo/bar/hoge` is given, use basename (hoge) to check existence

And I optimized it too. Since `brew list` and `brew info` are slow, I replaced them using `ls`.

## performance improvement

This is the time spent on 30 brew packages installation by itamae (with all packages installed beforehand)

### before 
```
14.94s user 5.85s system 97% cpu 21.262 total
```

### after
```
rake  4.68s user 1.87s system 99% cpu 6.556 total
```