### PR TITLE
Adds class method to clear backend

### DIFF
--- a/lib/specinfra/backend/base.rb
+++ b/lib/specinfra/backend/base.rb
@@ -8,6 +8,10 @@ module Specinfra
         @instance ||= self.new
       end
 
+      def self.clear
+        @instance = nil
+      end
+
       def initialize(config = {})
         @config = config
       end


### PR DESCRIPTION
When executing ServerSpec examples in the same process using `RSpec::Core::Runner.run` we need some way to clear the test suite state so the configuration for the previous tests does not impact on further test runs.

Within RSpec there is a [clear_examples](https://relishapp.com/rspec-staging/rspec-core/docs/running-specs-multiple-times-with-different-runner-options-in-the-same-process) method to do this. Within ServerSpec the problem is the backend connection is being re-used between runs and so even though we change the `host` we are in fact connecting to the host from the first test run.

This PR adds a mechanism to clear the backend, so it does not interfere with multiple runs.