### PR TITLE
Allow net-ssh 3.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in specinfra.gemspec
 gemspec
+
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  # net-ssh 3.x dropped Ruby 1.8 and 1.9 support.
+  gem 'net-ssh', '~> 2.7'
+end

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-scp"
-  spec.add_runtime_dependency "net-ssh", "~> 2.7"
+  spec.add_runtime_dependency "net-ssh", ">= 2.7", "< 3.1"
   spec.add_runtime_dependency "net-telnet"
   spec.add_runtime_dependency "sfl"
 


### PR DESCRIPTION
net-ssh 3.0.x has no breaking changes to do with specinfra.
https://github.com/net-ssh/net-ssh/blob/v3.0.1/CHANGES.txt