### PR TITLE
Added methods to count number of running processes

### DIFF
--- a/lib/specinfra/command/base/process.rb
+++ b/lib/specinfra/command/base/process.rb
@@ -4,6 +4,10 @@ class Specinfra::Command::Base::Process < Specinfra::Command::Base
       "ps -C #{escape(process)} -o #{opts[:format]} | head -1"
     end
 
+    def count(process)
+      "ps aux | grep -w -- #{escape(process)} | grep -v grep | wc -l"
+    end
+
     def check_is_running(process)
       "ps aux | grep -w -- #{escape(process)} | grep -qv grep"
     end

--- a/spec/command/base/process_spec.rb
+++ b/spec/command/base/process_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+set :os, { :family => nil }
+
+describe get_command(:count_process, 'foo') do
+  it { should eq 'ps aux | grep -w -- foo | grep -v grep | wc -l' }
+end


### PR DESCRIPTION
I have added a `count` method to Specinfra::Command::Base::Process and unit tests for this method.