### PR TITLE
Added sudo to exec backend

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -33,6 +33,9 @@ module Specinfra
         shell = get_config(:shell) || '/bin/sh'
         cmd = cmd.shelljoin if cmd.is_a?(Array)
         cmd = "#{shell.shellescape} -c #{cmd.to_s.shellescape}"
+        if sudo?
+          cmd = "#{sudo} #{cmd}"
+        end
 
         path = get_config(:path)
         if path
@@ -146,6 +149,28 @@ module Specinfra
         else
           cmd
         end
+      end
+
+      def sudo
+        if sudo_path = get_config(:sudo_path)
+          sudo_path += '/sudo'
+        else
+          sudo_path = 'sudo'
+        end
+
+        sudo_options = get_config(:sudo_options)
+        if sudo_options
+          sudo_options = sudo_options.shelljoin if sudo_options.is_a?(Array)
+          sudo_options = ' ' + sudo_options
+        end
+
+        "#{sudo_path.shellescape}#{sudo_options}"
+      end
+
+      def sudo?
+        uid = ENV['UID']
+        disable_sudo = get_config(:disable_sudo)
+        uid != '0' && !disable_sudo
       end
     end
   end


### PR DESCRIPTION
I am working on getting my infrastructure tests running in Travis CI. Since Travis CI is a virtualized environment, it is easier for me to use the `:exec` backend. In development, I use Vagrant with the `:ssh` backend to make resetting my server easy.

https://github.com/twolfson/twolfson.com-scripts

Unfortunately, while my tests pass on Vagrant due to `sudo` usage for sensitive files (e.g. `/etc/ssl/private`), they don't pass via `exec`. I could use `disable_sudo` for my `:ssh` backend but I feel like that isn't solving the problem.

Instead, I want to discuss adding the same `sudo` support from the `ssh` backend to the `exec` backend.

This PR is currently a proof of concept that only does the bare minimum (e.g. lacks `sudo_password` support, lacks `request_pty` for manual entry, no test updates yet).

What are your thoughts?