### PR TITLE
Lock down net-ssh inside of gemspec

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -20,7 +20,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-scp"
-  spec.add_runtime_dependency "net-ssh", ">= 2.7", "< 3.1"
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+    # net-ssh 3.x dropped Ruby 1.8 and 1.9 support.
+    spec.add_runtime_dependency "net-ssh", "~> 2.7"
+  else
+    spec.add_runtime_dependency "net-ssh", ">= 2.7", "< 3.1"
+  end
   spec.add_runtime_dependency "net-telnet"
   spec.add_runtime_dependency "sfl"
 


### PR DESCRIPTION
When I run `bundle update` to upgrade `serverspec`, my install fails with the following message:

```
Installing net-ssh 3.0.1 (was 2.9.2)

Gem::InstallError: net-ssh requires Ruby version >= 2.0.
Using net-telnet 0.1.1
...
An error occurred while installing net-ssh (3.0.1), and Bundler cannot continue.
Make sure that `gem install net-ssh -v '3.0.1'` succeeds before bundling.
```

I am running on `ruby 1.9.3p484` (vanilla version of Ruby on Ubuntu in a Vagrant instance) which is leading to the error. I am still pretty at novice at Ruby and their gems but the solution in this PR seemed to work based on trial/error with `git` URLs in a `Gemfile`.

In this PR:

- Repaired `net-ssh` install error for Ruby < 2.0.0

I'm going to cc all users on the thread in #505:

/cc @mizzy @eagletmt 