### PR TITLE
Fix PPA resource on Ubuntu 15.04

### DIFF
--- a/lib/specinfra/command/ubuntu/v15.rb
+++ b/lib/specinfra/command/ubuntu/v15.rb
@@ -1,1 +1,1 @@
-class Specinfra::Command::Ubuntu::V15 < Specinfra::Command::Debian::Base; end
+class Specinfra::Command::Ubuntu::V15 < Specinfra::Command::Ubuntu::Base; end


### PR DESCRIPTION
This should fix a bug on Ubuntu 15.04 (and probably 15.10, 15.x also) where the PPA resource does not work.

Error message due to this bug looks like:

```
1) foobar::default Ppa "foobar/ppa" should exist
            Failure/Error: it { should exist }
            NotImplementedError:
              check_exists is not implemented in Specinfra::Command::Debian::Base::Ppa
              /bin/sh -c uname\ -m
              x86_64

            # /tmp/verifier/gems/gems/specinfra-2.47.0/lib/specinfra/command_factory.rb:20:in `get'
            # /tmp/verifier/gems/gems/specinfra-2.47.0/lib/specinfra/runner.rb:26:in `run'
            # /tmp/verifier/gems/gems/specinfra-2.47.0/lib/specinfra/runner.rb:13:in `method_missing'
            # /tmp/verifier/gems/gems/serverspec-2.26.0/lib/serverspec/type/ppa.rb:4:in `exists?'
            # /tmp/verifier/suites/serverspec/default_spec.rb:7:in `block (3 levels) in <top (required)>'

         2) foobar::default Ppa "foobar/ppa" should be enabled
            Failure/Error: it { should be_enabled }
            NotImplementedError:
              check_is_enabled is not implemented in Specinfra::Command::Debian::Base::Ppa

            # /tmp/verifier/gems/gems/specinfra-2.47.0/lib/specinfra/command_factory.rb:20:in `get'
            # /tmp/verifier/gems/gems/specinfra-2.47.0/lib/specinfra/runner.rb:26:in `run'
            # /tmp/verifier/gems/gems/specinfra-2.47.0/lib/specinfra/runner.rb:13:in `method_missing'
            # /tmp/verifier/gems/gems/serverspec-2.26.0/lib/serverspec/type/ppa.rb:8:in `enabled?'
            # /tmp/verifier/gems/gems/serverspec-2.26.0/lib/serverspec/matcher/be_enabled.rb:6:in `block (2 levels) in <top (required)>'
            # /tmp/verifier/suites/serverspec/default_spec.rb:8:in `block (3 levels) in <top (required)>'
```

Error seems to be caused by the class `Specinfra::Command::Ubuntu::V15` inheriting from `Specinfra::Command::Debian::Base` instead of `Specinfra::Command::Ubuntu::Base`.

The PPA resource is not defined in the class `Specinfra::Command::Debian::Base`, and therefore will cause errors on anything using the Ubuntu v15 class.  In fact, I suspect that any other resources with specific command implementations for Ubuntu which do not also exist in Debian would not work in v15 unless this class inherits from `Specinfra::Command::Ubuntu::Base`.

Luckily, it appears that the [only Ubuntu-specific commands implemented][1] are: `service` and `ppa`.  Because `service` was specifically overridden to use SystemD on Ubuntu v15, only PPA should be affected.

[1]: https://github.com/mizzy/specinfra/tree/master/lib/specinfra/command/ubuntu/base