### PR TITLE
Restrict net-ssh to < 3.0 for Ruby < 2.0

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-scp"
-  spec.add_runtime_dependency "net-ssh", ">= 2.7", "< 3.1"
+  spec.add_runtime_dependency "net-ssh", ">= 2.7", (RUBY_VERSION >= "2.0" ? "< 3.1" : "< 3.0")
   spec.add_runtime_dependency "net-telnet"
   spec.add_runtime_dependency "sfl"
 


### PR DESCRIPTION
net-ssh 3.0 dropped support for Ruby < 2.0 causing an issue for
test-kitchen/busser: https://github.com/test-kitchen/busser/issues/32

In summary, older versions of Chef use Ruby < 2.0. When running kitchen
tests with busser-serverspec, it tries to install the serverspec gem,
attempts to install the latest allowable net-ssh (3.0.x) and fails as it does
not support Ruby < 2.0.