### PR TITLE
Correction to net-ssh version for Ruby < 2.0

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-scp"
-  spec.add_runtime_dependency "net-ssh", ">= 2.7", (RUBY_VERSION >= "2.0" ? "< 3.1" : "< 3.0")
+  spec.add_runtime_dependency "net-ssh", ">= 2.7", (RUBY_VERSION >= "2.0" ? "< 3.1" : "< 2.10")
   spec.add_runtime_dependency "net-telnet"
   spec.add_runtime_dependency "sfl"
 


### PR DESCRIPTION
On closer look, it was net-ssh [2.10](https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt#L25) that dropped support for Ruby < 2.0

Following up from #513