### PR TITLE
Fix command freebsd

### DIFF
--- a/lib/specinfra/command/freebsd/base/service.rb
+++ b/lib/specinfra/command/freebsd/base/service.rb
@@ -3,9 +3,8 @@ class Specinfra::Command::Freebsd::Base::Service < Specinfra::Command::Base::Ser
     def check_is_enabled(service, level=3)
       "service -e | grep -- #{escape(service)}"
     end
-
-    def check_is_running_under_daemontools(service)
-      "svstat /var/service/#{escape(service)} | grep -E 'up \\(pid [0-9]+\\)'"
+    def check_is_running_under_init(service)
+      "service #{escape(service)} status | grep -E 'as \\(pid [0-9]+\\)'"
     end
   end
 end


### PR DESCRIPTION
Avoid using third party commands of FreeBSD.
'service status' sub-command is supported in rc.subr framework.
'pw' command is offered to add/del user/groups .