### PR TITLE
Check arch package installation for group too

### DIFF
--- a/lib/specinfra/command/arch/base/package.rb
+++ b/lib/specinfra/command/arch/base/package.rb
@@ -5,7 +5,7 @@ class Specinfra::Command::Arch::Base::Package < Specinfra::Command::Linux::Base:
         grep = version.include?('-') ? "^#{escape(version)}$" : "^#{escape(version)}-"
         "pacman -Q #{escape(package)} | awk '{print $2}' | grep '#{grep}'"
       else
-        "pacman -Q #{escape(package)}"
+        "pacman -Q #{escape(package)} || pacman -Qg #{escape(package)}"
       end
     end
 


### PR DESCRIPTION
While I want to install Arch packages in base-devel group with just writing `package 'base-devel'` in itamae recipe, we can't check whether the group is installed or not by `pacman -Q`. To check package group, I changed `check_is_installed` to check `pacman -Qg` too.

Since package group itself does not have version, I didn't care about version for package group in this change.