### PR TITLE
Fix check_service_is_enabled_under_systemd for Debian jessie

### DIFF
--- a/lib/specinfra/command/debian/v8/service.rb
+++ b/lib/specinfra/command/debian/v8/service.rb
@@ -1,5 +1,14 @@
 class Specinfra::Command::Debian::V8::Service < Specinfra::Command::Debian::Base::Service
   class << self
     include Specinfra::Command::Module::Systemd
+
+    def check_is_enabled_under_systemd(service, level=nil)
+      [
+        super(service),
+        "ls /etc/rc[S5].d/S??#{escape(service)} >/dev/null 2>/dev/null"
+      ].join('||')
+    end
+
+    alias_method :check_is_enabled, :check_is_enabled_under_systemd
   end
 end


### PR DESCRIPTION
Hi, mizzy-san. This patch is to fix `check_service_is_enabled_under_systemd` on Debian 8.


Debian 8.x "jessie" has problem on Systemd's SysV compatibility that invoking `systemctl is-enabled $SERVICE` on a SysV service always fails. Due to this problem Specinfra fails to correctly check whether the service is enabled.

This patch resolves the problem by "backporting" the checking mechanism from Debian "testing".

The next Debian major release will likely to fix the problem by adopting `systemd-sysv-install`, which is an abstraction layer for SysV services management tools such as `update-rc.d`. Its implementation[1] for Debian has a command to test if a SysV service is enabled.

```sh
ls $ROOT/etc/rc[S5].d/S??$NAME >/dev/null 2>/dev/null
```

This patch makes `check_service_is_enabled_under_systemd` also perform this check when `systemctl is-enabled` has failed.

[1] https://anonscm.debian.org/cgit/pkg-systemd/systemd.git/tree/debian/extra/systemd-sysv-install?h=debian/228-4

----

I have an integration test to check this patch works: https://github.com/hanazuki/specinfra-integration-test