### PR TITLE
Add the option to emulate an interactive interactive shell

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -32,7 +32,13 @@ module Specinfra
       def build_command(cmd)
         shell = get_config(:shell) || '/bin/sh'
         cmd = cmd.shelljoin if cmd.is_a?(Array)
-        cmd = "#{shell.shellescape} -c #{cmd.to_s.shellescape}"
+        shell = shell.shellescape
+
+        if get_config(:interactive_shell)
+          shell << " -i"
+        end
+
+        cmd = "#{shell} -c #{cmd.to_s.shellescape}"
 
         path = get_config(:path)
         if path

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -6,6 +6,7 @@ module Specinfra
         :env,
         :path,
         :shell,
+        :interactive_shell,
         :pre_command,
         :stdout,
         :stderr,

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -46,6 +46,20 @@ describe Specinfra::Backend::Exec do
       end
     end
 
+    context 'with an interactive shell' do
+      before do
+        RSpec.configure {|c| c.interactive_shell = true }
+      end
+
+      after do
+        RSpec.configure {|c| c.interactive_shell = nil }
+      end
+
+      it 'should emulate an interactive shell' do
+        expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq '/bin/sh -i -c test\ -f\ /etc/passwd'
+      end
+    end
+
     context 'with custom path' do
       before do
         RSpec.configure {|c| c.path = '/opt/bin:/opt/foo/bin:$PATH' }


### PR DESCRIPTION
I've run into several instances where I need a file(s) in `/etc/profile.d` to be loaded before running a test case. Unfortunately, these files are only included in interactive shells. Rather than hard coding paths and building convoluted `:pre_command` or command examples, it would be easier if Specinfra could emulate an interactive shell and load these files automatically.