### PR TITLE
Remove ruby22 from allow_failures on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,6 @@ environment:
     - ruby_version: "21"
     - ruby_version: "22"
 
-matrix:
-  allow_failures:
-    - ruby_version: "22" # waiting for net-ssh update
-
 clone_depth: 5
 
 cache:


### PR DESCRIPTION
No longer needed this rule.

And, this PR will solves https://ci.appveyor.com/project/serverspec-windows-integration-test/specinfra/build/337/job/p329fqqq30aaadcb because updating appveyor.yml will purge older caches.