### PR TITLE
yumrepo: Support non-verbose mode(*) and old metadata(!)

### DIFF
--- a/lib/specinfra/command/redhat/base/yumrepo.rb
+++ b/lib/specinfra/command/redhat/base/yumrepo.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Redhat::Base::Yumrepo < Specinfra::Command::Linux::Base::Yumrepo
   class << self
     def check_exists(repository)
-      "yum repolist all -C | grep -E \"^#{escape(repository)}\(\\s\|$\|\\/)\""
+      "yum repolist all -C | grep -qsE \"^[\\!\\*]?#{escape(repository)}\(\\s\|$\|\\/)\""
     end
 
     def check_is_enabled(repository)


### PR DESCRIPTION
Commit 35f6f6bf only fixed the enabled check. Exist check also needs to support the same output format. See yum(8) repolist documentation for details on '*' and '!' prefix in first column.