### PR TITLE
Windows service properties support

### DIFF
--- a/lib/specinfra/command/windows/base/service.rb
+++ b/lib/specinfra/command/windows/base/service.rb
@@ -27,5 +27,26 @@ class Specinfra::Command::Windows::Base::Service < Specinfra::Command::Windows::
         exec "(FindService -name '#{service}').State -eq 'Running'"
       end
     end
+      
+    def check_has_property(service, property)
+        print property.keys
+        command = []
+        property.keys.each do |key|
+          value= property[key]
+          command <<"(FindService -name '#{service}').#{key} -eq '#{value}'"
+        end
+        executable = command.join(' -and ')
+        Backend::PowerShell::Command.new do
+          using 'find_service.ps1'
+          exec executable
+        end
+    end
+    
+    def get_property(service)
+      Backend::PowerShell::Command.new do
+        using 'find_service.ps1'
+        exec "(FindService -name '#{service}') | Select-Object *"
+      end
+    end
   end
 end

--- a/lib/specinfra/command/windows/base/service.rb
+++ b/lib/specinfra/command/windows/base/service.rb
@@ -29,7 +29,6 @@ class Specinfra::Command::Windows::Base::Service < Specinfra::Command::Windows::
     end
       
     def check_has_property(service, property)
-        print property.keys
         command = []
         property.keys.each do |key|
           value= property[key]

--- a/spec/command/windows/service_spec.rb
+++ b/spec/command/windows/service_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'windows'
+RSpec.describe Specinfra::Command::Windows::Base::Service do
+    let(:service_name) { "Power" }
+    let(:property_map) {{"StartName"=>"Local System","State"=>"Running","StartMode"=>"Auto"}}
+    describe "#check_service_is_running" do
+        it "" do
+            command = get_command(:check_service_is_running, service_name)
+            expect(command.script).to eq("(FindService -name 'Power').State -eq 'Running'")
+        end
+    end
+    describe "#check_service_is_enabled" do
+        it "" do
+            command = get_command(:check_service_is_enabled, service_name)
+            expect(command.script).to eq ("(FindService -name 'Power').StartMode -eq 'Auto'")
+        end
+    end
+    describe "#has_property" do
+        it "includes (FindService -name 'Power').StartName -eq 'Local System" do
+            command = get_command(:check_service_has_property, service_name,property_map)
+            expect(command.script).to include ("(FindService -name 'Power').StartName -eq 'Local System'")
+        end
+        it "includes (FindService -name 'Power').State -eq 'Running" do
+            command = get_command(:check_service_has_property, service_name,property_map)
+            expect(command.script).to include ("(FindService -name 'Power').State -eq 'Running'")
+        end
+        it "includes (FindService -name 'Power').StartMode -eq 'Auto" do
+            command = get_command(:check_service_has_property, service_name,property_map)
+            expect(command.script).to include ("(FindService -name 'Power').StartMode -eq 'Auto'")
+        end
+    end
+end


### PR DESCRIPTION
Hey mizzy,

I am currently working with windows based machines and wanted to add support for windows service properties. I have added a method for check_has_property and get_property. I have also added a set of test for Windows Service Commands. If you see anything in my code that needs adjustment just tell me and I will change it. 
Also, Should I be using "expect" or "should" in the test?

Thanks
-Charlie