### PR TITLE
Added option to emulate a login shell

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -38,6 +38,10 @@ module Specinfra
           shell << " -i"
         end
 
+        if get_config(:login_shell)
+          shell << " -l"
+        end
+
         cmd = "#{shell} -c #{cmd.to_s.shellescape}"
 
         path = get_config(:path)

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -7,6 +7,7 @@ module Specinfra
         :path,
         :shell,
         :interactive_shell,
+        :login_shell,
         :pre_command,
         :stdout,
         :stderr,

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -60,6 +60,20 @@ describe Specinfra::Backend::Exec do
       end
     end
 
+    context 'with an login shell' do
+      before do
+        RSpec.configure {|c| c.login_shell = true }
+      end
+
+      after do
+        RSpec.configure {|c| c.login_shell = nil }
+      end
+
+      it 'should emulate an login shell' do
+        expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq '/bin/sh -l -c test\ -f\ /etc/passwd'
+      end
+    end
+
     context 'with custom path' do
       before do
         RSpec.configure {|c| c.path = '/opt/bin:/opt/foo/bin:$PATH' }


### PR DESCRIPTION
In #520, `:interactive_shell` option (which adds `-i` option to shell) was added,
but I need to add `-l` option to shell to load files in `/etc/profile.d` on my environement.
So I want to add `:login_shell` option to specinfra.
