### PR TITLE
fix syntax error in array push operator

### DIFF
--- a/lib/specinfra/command/windows/base/service.rb
+++ b/lib/specinfra/command/windows/base/service.rb
@@ -32,7 +32,7 @@ class Specinfra::Command::Windows::Base::Service < Specinfra::Command::Windows::
         command = []
         property.keys.each do |key|
           value= property[key]
-          command <<"(FindService -name '#{service}').#{key} -eq '#{value}'"
+          command << "(FindService -name '#{service}').#{key} -eq '#{value}'"
         end
         executable = command.join(' -and ')
         Backend::PowerShell::Command.new do


### PR DESCRIPTION
started getting error:
```
Fetching: specinfra-2.51.2.gem (100%)
Successfully installed specinfra-2.51.2
Parsing documentation for specinfra-2.51.2

RDoc::Parser::Ruby failure around line 52 of
lib/specinfra/command/windows/base/service.rb


"\n    end\n  end\nend\n"
Before reporting this, could you check that the file you're documenting
has proper syntax:

  /opt/chef/embedded/bin/ruby -c lib/specinfra/command/windows/base/service.rb

RDoc is not a full Ruby parser and will fail when fed invalid ruby programs.

The internal error was:

        (RDoc::RubyLex::Error) Missing terminating (FindService -name '#{service}').#{key} -eq '#{value}' for string

ERROR:  While executing gem ... (RDoc::RubyLex::Error)
    Missing terminating (FindService -name '#{service}').#{key} -eq '#{value}' for string
```