### PR TITLE
adding new get_interface_ipv4/v6_address feature

### DIFF
--- a/lib/specinfra/command/darwin/base/interface.rb
+++ b/lib/specinfra/command/darwin/base/interface.rb
@@ -32,6 +32,15 @@ class Specinfra::Command::Darwin::Base::Interface < Specinfra::Command::Base::In
       "ifconfig #{interface} inet6 | grep 'inet6 #{ip_address}'"
     end
 
+    def get_ipv4_address(interface)
+      "ifconfig #{interface} inet | grep inet | awk '{print $2}'"
+    end
+
+    def get_ipv6_address(interface)
+      # Awk refuses to print '/' even with using escapes or hex so workaround with sed employed here.
+      "ifconfig #{interface} inet6 | grep inet6 | awk '{print $2$3$4}' | sed 's/prefixlen/\//'; exit"
+    end
+
     def get_link_state(interface)
       # Checks if interfaces is administratively up with the -u arg.
       # L1 check via status. Virtual interfaces like tapX missing the status will report up.

--- a/lib/specinfra/command/freebsd/base/interface.rb
+++ b/lib/specinfra/command/freebsd/base/interface.rb
@@ -1,4 +1,4 @@
-class Specinfra::Command::Freebsd::Base::Interface < Specinfra::Command::Base::Interface 
+class Specinfra::Command::Freebsd::Base::Interface < Specinfra::Command::Base::Interface
   class << self
     def check_exists(name)
       "ifconfig #{name}"
@@ -8,7 +8,7 @@ class Specinfra::Command::Freebsd::Base::Interface < Specinfra::Command::Base::I
       ip_address = ip_address.dup
       if ip_address =~ /\/\d+$/
         # remove the prefix - better would be to calculate the netmask
-        ip_address.gsub!(/\/\d+$/, "") 
+        ip_address.gsub!(/\/\d+$/, "")
       end
       ip_address << " "
       ip_address.gsub!(".", "\\.")
@@ -20,16 +20,25 @@ class Specinfra::Command::Freebsd::Base::Interface < Specinfra::Command::Base::I
       (ip_address, prefixlen) = ip_address.split(/\//)
       ip_address.downcase!
       if ip_address =~ /^fe80::/i
-        # link local needs the scope (interface) appended 
+        # link local needs the scope (interface) appended
         ip_address << "%#{interface}"
-      end 
-      unless prefixlen.to_s.empty? 
-        # append prefixlen 
+      end
+      unless prefixlen.to_s.empty?
+        # append prefixlen
         ip_address << " prefixlen #{prefixlen}"
-      else 
+      else
         ip_address << " "
       end
       "ifconfig #{interface} inet6 | grep 'inet6 #{ip_address}'"
+    end
+
+    def get_ipv4_address(interface)
+      "ifconfig #{interface} inet | grep inet | awk '{print $2}'"
+    end
+
+    def get_ipv6_address(interface)
+      # Awk refuses to print '/' even with using escapes or hex so workaround with sed employed here.
+      "ifconfig #{interface} inet6 | grep inet6 | awk '{print $2$3$4}' | sed 's/prefixlen/\//'; exit"
     end
 
     def get_link_state(interface)

--- a/lib/specinfra/command/linux/base/interface.rb
+++ b/lib/specinfra/command/linux/base/interface.rb
@@ -34,9 +34,16 @@ class Specinfra::Command::Linux::Base::Interface < Specinfra::Command::Base::Int
       "ip -6 addr show #{interface} | grep 'inet6 #{ip_address}'"
     end
 
+    def get_ipv4_address(interface)
+      "ip -4 addr show #{interface} | grep #{interface}$ | awk '{print $2}'"
+    end
+
+    def get_ipv6_address(interface)
+      "ip -6 addr show #{interface} | grep inet6 | awk '{print $2}'"
+    end
+
     def get_link_state(name)
       "cat /sys/class/net/#{name}/operstate"
     end
   end
 end
-

--- a/lib/specinfra/command/openbsd/base/interface.rb
+++ b/lib/specinfra/command/openbsd/base/interface.rb
@@ -1,4 +1,4 @@
-class Specinfra::Command::Openbsd::Base::Interface < Specinfra::Command::Base::Interface 
+class Specinfra::Command::Openbsd::Base::Interface < Specinfra::Command::Base::Interface
   class << self
     def check_exists(name)
       "ifconfig #{name}"
@@ -12,7 +12,7 @@ class Specinfra::Command::Openbsd::Base::Interface < Specinfra::Command::Base::I
       ip_address = ip_address.dup
       if ip_address =~ /\/\d+$/
         # remove the prefix - better would be to calculate the netmask
-        ip_address.gsub!(/\/\d+$/, "") 
+        ip_address.gsub!(/\/\d+$/, "")
       end
       ip_address << " "
       ip_address.gsub!(".", "\\.")
@@ -24,22 +24,31 @@ class Specinfra::Command::Openbsd::Base::Interface < Specinfra::Command::Base::I
       (ip_address, prefixlen) = ip_address.split(/\//)
       ip_address.downcase!
       if ip_address =~ /^fe80::/i
-        # link local needs the scope (interface) appended 
+        # link local needs the scope (interface) appended
         ip_address << "%#{interface}"
-      end 
-      unless prefixlen.to_s.empty? 
-        # append prefixlen 
+      end
+      unless prefixlen.to_s.empty?
+        # append prefixlen
         ip_address << " prefixlen #{prefixlen}"
-      else 
+      else
         ip_address << " "
       end
       "ifconfig #{interface} inet6 | grep 'inet6 #{ip_address}'"
     end
 
+    def get_ipv4_address(interface)
+      "ifconfig #{interface} inet | grep inet | awk '{print $2}'"
+    end
+
+    def get_ipv6_address(interface)
+      # Awk refuses to print '/' even with using escapes or hex so workaround with sed employed here.
+      "ifconfig #{interface} inet6 | grep inet6 | awk '{print $2$3$4}' | sed 's/prefixlen/\//'; exit"
+    end
+
     def get_link_state(interface)
       # Checks if interfaces is administratively up by parsing the options.
       # L1 check via status. Virtual interfaces like tapX missing the status will report up.
-      # Emulates operstate in linux with exception of the unknown status. 
+      # Emulates operstate in linux with exception of the unknown status.
       %Q{ifconfig #{interface} 2>&1 | awk -v s=down -F '[:<>,]' } +
       %Q{'NR == 1 && $3 == "UP" { s="up" }; /status:/ && $2 != " active" { s="down" }; END{ print s }'}
     end

--- a/spec/command/darwin/interface_spec.rb
+++ b/spec/command/darwin/interface_spec.rb
@@ -32,7 +32,14 @@ describe get_command(:check_interface_has_ipv4_address, 'en0', '192.168.0.123/24
   it { should eq "ifconfig en0 inet | grep 'inet 192\\.168\\.0\\.123 '" }
 end
 
+describe get_command(:get_interface_ipv4_address, 'en0') do
+  it { should eq "ifconfig en0 inet | grep inet | awk '{print $2}'" }
+end
+
+describe get_command(:get_interface_ipv6_address, 'en0') do
+  it { should eq "ifconfig en0 inet6 | grep inet6 | awk '{print $2$3$4}' | sed 's/prefixlen/\//'; exit" }
+end
+
 describe get_command(:get_interface_link_state, 'en0') do
   it { should eq %Q{ifconfig -u en0 2>&1 | awk -v s=up '/status:/ && $2 != "active" { s="down" }; END {print s}'} }
 end
-

--- a/spec/command/freebsd/interface_spec.rb
+++ b/spec/command/freebsd/interface_spec.rb
@@ -27,6 +27,14 @@ describe get_command(:check_interface_has_ipv4_address, 'vtnet0', '192.168.0.123
   it { should eq "ifconfig vtnet0 inet | grep 'inet 192\\.168\\.0\\.123 '" }
 end
 
+describe get_command(:get_interface_ipv4_address, 'vtnet0') do
+  it { should eq "ifconfig vtnet0 inet | grep inet | awk '{print $2}'" }
+end
+
+describe get_command(:get_interface_ipv6_address, 'vtnet0') do
+  it { should eq "ifconfig vtnet0 inet6 | grep inet6 | awk '{print $2$3$4}' | sed 's/prefixlen/\//'; exit" }
+end
+
 describe get_command(:get_interface_link_state, 'vtnet0') do
   it { should eq %Q{ifconfig -u vtnet0 2>&1 | awk -v s=up '/status:/ && $2 != "active" { s="down" }; END {print s}'} }
 end

--- a/spec/command/linux/interface_spec.rb
+++ b/spec/command/linux/interface_spec.rb
@@ -19,6 +19,14 @@ describe get_command(:check_interface_has_ipv4_address, 'eth0', '192.168.0.123/2
   it { should eq "ip -4 addr show eth0 | grep 'inet 192\\.168\\.0\\.123/24 '" }
 end
 
+describe get_command(:get_interface_ipv4_address, 'eth0') do
+  it { should eq "ip -4 addr show eth0 | grep eth0$ | awk '{print $2}'" }
+end
+
+describe get_command(:get_interface_ipv6_address, 'eth0') do
+  it { should eq "ip -6 addr show eth0 | grep inet6 | awk '{print $2}'" }
+end
+
 describe get_command(:get_interface_link_state, 'eth0') do
   it { should eq "cat /sys/class/net/eth0/operstate" }
 end

--- a/spec/command/openbsd/interface_spec.rb
+++ b/spec/command/openbsd/interface_spec.rb
@@ -4,7 +4,7 @@ property[:os] = nil
 set :os, :family => 'openbsd'
 
 describe get_command(:get_interface_speed_of, 'vio0') do
-  it { should eq "ifconfig vio0 | grep 'media\:' | perl -pe 's|.*media\:.*\\((.*?)\\)|\\1|'" } 
+  it { should eq "ifconfig vio0 | grep 'media\:' | perl -pe 's|.*media\:.*\\((.*?)\\)|\\1|'" }
 end
 
 describe get_command(:check_interface_has_ipv6_address, 'vio0', '2001:0db8:bd05:01d2:288a:1fc0:0001:10ee') do
@@ -31,8 +31,16 @@ describe get_command(:check_interface_has_ipv4_address, 'vio0', '192.168.0.123/2
   it { should eq "ifconfig vio0 inet | grep 'inet 192\\.168\\.0\\.123 '" }
 end
 
+describe get_command(:get_interface_ipv4_address, 'vio0') do
+  it { should eq "ifconfig vio0 inet | grep inet | awk '{print $2}'" }
+end
+
+describe get_command(:get_interface_ipv6_address, 'vio0') do
+  it { should eq "ifconfig vio0 inet6 | grep inet6 | awk '{print $2$3$4}' | sed 's/prefixlen/\//'; exit" }
+end
+
 describe get_command(:get_interface_link_state, 'vio0') do
   it do should eq %Q{ifconfig vio0 2>&1 | awk -v s=down -F '[:<>,]' } +
                   %Q{'NR == 1 && $3 == "UP" { s="up" }; /status:/ && $2 != " active" { s="down" }; END{ print s }'}
-  end 
+  end
 end


### PR DESCRIPTION
I have a situation where I have over ten thousand linux servers that each fit into one of four roles.  Each of these four roles has ipv4 interfaces and interface aliases that fit a regular expression by role and interface.  I need to be able to test for this.  This is a precursor to a future serverspec PR.