### PR TITLE
Allow backslash in crontab

### DIFF
--- a/lib/specinfra/command/base/cron.rb
+++ b/lib/specinfra/command/base/cron.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Base::Cron < Specinfra::Command::Base
   class << self
     def check_has_entry(user, entry)
-      entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]')
+      entry_escaped = entry.gsub(/\\/, '\\\\\\').gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]')
       grep_command = "grep -v '^[[:space:]]*#' | grep -- ^#{escape(entry_escaped)}$"
       if user.nil?
         "crontab -l | #{grep_command}"


### PR DESCRIPTION
This PR is to fix Serverspec fails in case backslash exists in crontab.

For example,
```
* * * * * touch /tmp/file.`date +\%Y\%m\%d`
```