### PR TITLE
Add syntax for protocol and IP address checking in OS X

### DIFF
--- a/lib/specinfra/command/darwin/base/port.rb
+++ b/lib/specinfra/command/darwin/base/port.rb
@@ -1,8 +1,10 @@
 class Specinfra::Command::Darwin::Base::Port < Specinfra::Command::Base::Port
   class << self
     def check_is_listening(port, options={})
-      regexp = ":#{port} "
-      "lsof -nP -iTCP -sTCP:LISTEN | grep -- #{escape(regexp)}"
+      regexp = ".*:#{port}"
+      regexp = ".*#{options[:local_address]}#{regexp}" if options[:local_address]
+      regexp = "#{options[:protocol]}#{regexp}" if options[:protocol]
+      "lsof -nP | grep --ignore-case --extended-regexp -- '#{regexp}'"
     end
   end
 end


### PR DESCRIPTION
I'm really not sure if using `shellescape` had any reason here, but it posed problem with `*` being escaped twice ie. `\\\*` which then `grep` did not handle well. I had not idea what to do about it, so I just removed `escape`.

Formally current regexp syntax for IP address should have `.` escaped to match the dot, but it does not interfere if `grep` treats it just as wildcard for a single characters. IP addresses would be matched and there is zero chance for false positive as it comes before `:port`.