### PR TITLE
Add options to Command::Base::File

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -137,17 +137,20 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
       "stat -c %s #{escape(file)}"
     end
 
-    def change_mode(file, mode)
-      "chmod #{mode} #{escape(file)}"
+    def change_mode(file, mode, options = {})
+      option = '-R' if options[:recursive]
+      "chmod #{option} #{mode} #{escape(file)}".squeeze(' ')
     end
 
-    def change_owner(file, owner, group=nil)
+    def change_owner(file, owner, group=nil, options = {})
+      option = '-R' if options[:recursive]
       owner = "#{owner}:#{group}" if group
-      "chown #{owner} #{escape(file)}"
+      "chown #{option} #{owner} #{escape(file)}".squeeze(' ')
     end
 
-    def change_group(file, group)
-      "chgrp #{group} #{escape(file)}"
+    def change_group(file, group, options = {})
+      option = '-R' if options[:recursive]
+      "chgrp #{option} #{group} #{escape(file)}".squeeze(' ')
     end
 
     def create_as_directory(file)

--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -154,8 +154,10 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
       "mkdir -p #{escape(file)}"
     end
 
-    def copy(src, dest)
-      "cp #{escape(src)} #{escape(dest)}"
+    def copy(src, dest, options = {})
+      option = '-p'
+      option << 'R' if options[:recursive]
+      "cp #{option} #{escape(src)} #{escape(dest)}"
     end
 
     def move(src, dest)

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -14,6 +14,10 @@ describe get_command(:change_file_mode, '/tmp', '0644') do
   it { should eq 'chmod 0644 /tmp' }
 end
 
+describe get_command(:change_file_mode, '/tmp', '0644', :recursive => true) do
+  it { should eq 'chmod -R 0644 /tmp' }
+end
+
 describe get_command(:change_file_owner, '/tmp', 'root') do
   it { should eq 'chown root /tmp' }
 end
@@ -22,8 +26,16 @@ describe get_command(:change_file_owner, '/tmp', 'root', 'root') do
   it { should eq 'chown root:root /tmp' }
 end
 
+describe get_command(:change_file_owner, '/tmp', 'root', 'root', :recursive => true) do
+  it { should eq 'chown -R root:root /tmp' }
+end
+
 describe get_command(:change_file_group, '/tmp', 'root') do
   it { should eq 'chgrp root /tmp' }
+end
+
+describe get_command(:change_file_group, '/tmp', 'root', :recursive => true) do
+  it { should eq 'chgrp -R root /tmp' }
 end
 
 describe get_command(:create_file_as_directory, '/tmp') do

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -38,6 +38,14 @@ describe get_command(:get_file_owner_group, '/tmp') do
   it { should eq 'stat -c %G /tmp' }
 end
 
+describe get_command(:copy_file, '/src', '/dest') do
+  it { should eq 'cp -p /src /dest' }
+end
+
+describe get_command(:copy_file, '/src', '/dest', :recursive => true) do
+  it { should eq 'cp -pR /src /dest' }
+end
+
 describe get_command(:move_file, '/src', '/dest') do
   it { should eq 'mv /src /dest' }
 end


### PR DESCRIPTION
This pull request is reference to [itamae-kitchen/itamae#191](https://github.com/itamae-kitchen/itamae/pull/191).

- Add `-p` option to `copy` to preserve attributes.
- Add `-R` option to `copy` to copy a directory.
- Add `-R` option to `change_mode`, `change_owner` and `change_group`.