### PR TITLE
Return $TRUE and $FALSE in Windows is_owned_by command

### DIFF
--- a/lib/specinfra/command/windows/base/file.rb
+++ b/lib/specinfra/command/windows/base/file.rb
@@ -108,7 +108,7 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
 
     def check_is_owned_by(file, owner)
       Backend::PowerShell::Command.new do
-        exec "$(if((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}' -or ((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}').Length -gt 0){ 0 } else { 1 })"
+        exec "$(if((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}' -or ((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}').Length -gt 0){ $TRUE } else { $FALSE })"
       end
     end
 


### PR DESCRIPTION
The Windows implementation of `is_owned_by` failed all the time because it returned 0 and 1 in the command but `ScriptHelper#create_script` checks for a `Boolean` value.