### PR TITLE
Docker backend accepts send_file when base_image isn't set, but container is set

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -40,14 +40,17 @@ module Specinfra
       end
 
       def send_file(from, to)
-        if @base_image.nil?
-          fail 'Cannot call send_file without docker_image.'
+        if @base_image
+          @images << commit_container if @container
+          @images << current_image.insert_local('localPath' => from, 'outputPath' => to)
+          cleanup_container
+          create_and_start_container
+        elsif @container
+          # This needs Docker >= 1.8
+          @container.archive_in(from, to)
+        else
+          fail 'Cannot call send_file without docker_image or docker_container.'
         end
-
-        @images << commit_container if @container
-        @images << current_image.insert_local('localPath' => from, 'outputPath' => to)
-        cleanup_container
-        create_and_start_container
       end
 
       def commit_container


### PR DESCRIPTION
This PR allows Docker backend to send file from local to running container.

Since Docker 1.8, we can copy file from local to container. I use this feature in this PR.
(Ref) https://blog.docker.com/2015/08/docker-1-8-content-trust-toolbox-registry-orchestration/

Could you check and merge it if you think OK?