### PR TITLE
Add hardcoded path to brew

### DIFF
--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -3,7 +3,7 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     def check_is_installed(package, version=nil)
       escaped_package = escape(File.basename(package))
       if version
-        cmd = %Q[brew info #{escaped_package} | grep -E "^$(brew --prefix)/Cellar/#{escaped_package}/#{escape(version)}"]
+        cmd = %Q[/usr/local/bin/brew info #{escaped_package} | grep -E "^$(/usr/local/bin/brew --prefix)/Cellar/#{escaped_package}/#{escape(version)}"]
       else
         cmd = "#{brew_list} | grep -E '^#{escaped_package}$'"
       end
@@ -15,7 +15,7 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     def check_is_installed_by_homebrew_cask(package, version=nil)
       escaped_package = escape(File.basename(package))
       if version
-        cmd = "brew cask info #{escaped_package} | grep -E '^/opt/homebrew-cask/Caskroom/#{escaped_package}/#{escape(version)}'"
+        cmd = "/usr/local/bin/brew cask info #{escaped_package} | grep -E '^/opt/homebrew-cask/Caskroom/#{escaped_package}/#{escape(version)}'"
       else
         cmd = "#{brew_cask_list} | grep -E '^#{escaped_package}$'"
       end
@@ -30,20 +30,20 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
 
     def install(package, version=nil, option='')
       # Homebrew doesn't support to install specific version.
-      cmd = "brew install #{option} '#{package}'"
+      cmd = "/usr/local/bin/brew install #{option} '#{package}'"
     end
 
     def remove(package, option='')
-      cmd = "brew uninstall #{option} '#{package}'"
+      cmd = "/usr/local/bin/brew uninstall #{option} '#{package}'"
     end
 
     def get_version(package, opts=nil)
-      %Q[ls -1 "$(brew --prefix)/Cellar/#{package}/" | tail -1]
+      %Q[ls -1 "$(/usr/local/bin/brew --prefix)/Cellar/#{package}/" | tail -1]
     end
 
     def brew_list
       # Since `brew list` is slow, directly check Cellar directory
-      'ls -1 "$(brew --prefix)/Cellar/"'
+      'ls -1 "$(/usr/local/bin/brew --prefix)/Cellar/"'
     end
 
     def brew_cask_list


### PR DESCRIPTION
When checking installed packages with `package` on OSX through SSH, Serverspec always reported packages being not installed. Locally it worked with no problems.

----

The path to `brew` is set by default in `/etc/paths`. The problem is that when shell is called with `/bin/sh` it does not source this file and all references to `brew` in specinfra's `package.rb` fail to find it.

It looks like this:
```
# ssh vagrant@127.0.0.1 -p 2222 /bin/sh -lc 'which\ brew'
#
```

One possible solution was to change shell callout to `/bin/bash` and add `-l`, but I failed to find where do you set it in Serverspec/Specinfra for Darwin.
```
# ssh vagrant@127.0.0.1 -p 2222 /bin/bash -lc 'which\ brew'
/usr/local/bin/brew
```

I am not sure if this (hardcoding) is the best solution, but lacking insight into Specinfra/Specinfo I have no better idea for now.