### PR TITLE
Use Write-Host instead of Out-String for Windows file content

### DIFF
--- a/lib/specinfra/command/windows/base/file.rb
+++ b/lib/specinfra/command/windows/base/file.rb
@@ -43,7 +43,7 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
     end
 
     def get_content(file)
-      %Q!Get-Content("#{file}") | Out-String!
+      %Q!Get-Content("#{file}") | Write-Host!
     end
 
     def get_md5sum(file)


### PR DESCRIPTION
`Out-String` introduces extra line breaks in the content, whereas `Write-Host` does not. I had a test to verify the content of a file that had a line longer than 80 characters. The test was failing because the content grabbed by `Get-Content | Out-String` included a newline that is not in the actual content. Switching to `Write-Host` eliminated the extra newline.