### PR TITLE
SLES 12 Support

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -215,6 +215,12 @@ require 'specinfra/command/opensuse'
 require 'specinfra/command/opensuse/base'
 require 'specinfra/command/opensuse/base/service'
 
+# SLES (inherit SuSE)
+require 'specinfra/command/sles'
+require 'specinfra/command/sles/base'
+require 'specinfra/command/sles/v12'
+require 'specinfra/command/sles/v12/service'
+
 # FreeBSD (inherit Base)
 require 'specinfra/command/freebsd'
 require 'specinfra/command/freebsd/base'

--- a/lib/specinfra/command/sles.rb
+++ b/lib/specinfra/command/sles.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Sles; end

--- a/lib/specinfra/command/sles/base.rb
+++ b/lib/specinfra/command/sles/base.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Sles::Base < Specinfra::Command::Suse::Base
+end

--- a/lib/specinfra/command/sles/v12.rb
+++ b/lib/specinfra/command/sles/v12.rb
@@ -1,0 +1,3 @@
+class Specinfra::Command::Sles::V12 < Specinfra::Command::Sles::Base
+end
+

--- a/lib/specinfra/command/sles/v12/service.rb
+++ b/lib/specinfra/command/sles/v12/service.rb
@@ -1,0 +1,5 @@
+class Specinfra::Command::Sles::V12::Service < Specinfra::Command::Sles::Base::Service
+  class << self
+    include Specinfra::Command::Module::Systemd
+  end
+end

--- a/lib/specinfra/helper/detect_os/suse.rb
+++ b/lib/specinfra/helper/detect_os/suse.rb
@@ -4,7 +4,7 @@ class Specinfra::Helper::DetectOs::Suse < Specinfra::Helper::DetectOs
       line = run_command('cat /etc/SuSE-release').stdout
       if line =~ /SUSE Linux Enterprise Server (\d+)/
         release = $1
-        family = 'suse'
+        family = 'sles'
       elsif line =~ /openSUSE (\d+\.\d+|\d+)/
         release = $1
         family = 'opensuse'

--- a/spec/helper/detect_os/suse_spec.rb
+++ b/spec/helper/detect_os/suse_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'specinfra/helper/detect_os/suse'
+
+describe Specinfra::Helper::DetectOs::Suse do
+  suse = Specinfra::Helper::DetectOs::Suse.new(:exec)
+  it 'Should return opensuse 13 when openSUSE 13.2 is installed.' do
+    allow(suse).to receive(:run_command) {
+        CommandResult.new(:stdout => 'openSUSE 13.2 (x86_64)', :exit_status => 0)
+    }
+    expect(suse.detect).to include(
+      :family  => 'opensuse',
+      :release => '13.2'
+    )
+  end
+  it 'Should return sles 12 when SUSE Linux Enterprise Server 12 is installed.' do
+    allow(suse).to receive(:run_command) {
+      CommandResult.new(:stdout => 'SUSE Linux Enterprise Server 12', :exit_status => 0)
+    }
+    expect(suse.detect).to include(
+      :family  => 'sles',
+      :release => '12'
+    )
+  end
+end


### PR DESCRIPTION
From SLES 12 onward, the default init system became systemd and thus needs a fix here to correctly define the init system. I did some very light acceptance testing with SLES 12 and OpenSuSE 13 to verify things are sane. Added some tests as well.

I am **very likely** missing some things here or doing something wrong, so please advise if there are other places I need to update in the code.

This is a potentially breaking change downstream as the SuSE detection is either opensuse or sles without any plain 'suse' detection anymore, so I'm not sure if there's anything that needs to be done to mitigate that, though it does carry on the intent of #60 to specify the SLES and OpenSuSE are inherited distros from SuSE in general.