### PR TITLE
Allowing the use of net-ssh < 4.0 if using Ruby 2.0+

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-scp"
-  spec.add_runtime_dependency "net-ssh", ">= 2.7", (RUBY_VERSION >= "2.0" ? "< 3.1" : "< 2.10")
+  spec.add_runtime_dependency "net-ssh", ">= 2.7", "< 4.0"
   spec.add_runtime_dependency "net-telnet"
   spec.add_runtime_dependency "sfl"
 


### PR DESCRIPTION
Because net-ssh 3.1 is released and we would like to use it.  The changelog for differences between 3.0.2 and 3.1 is [here](https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt).  We have been testing with 3.1 and have yet to find any errors.

\cc @mizzy 