### PR TITLE
Consume remained stdout and stderr from buffer

### DIFF
--- a/spec/backend/exec/consume_exited_process_spec.rb
+++ b/spec/backend/exec/consume_exited_process_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+context 'when executed process had exited before read stdout and stderr,' do
+  let(:backend) { Specinfra::Backend::Exec.new }
+
+  it 'can consume stdout and stderr from buffer' do
+    allow(IO).to receive(:select).and_wrap_original { |m, *args| sleep 1; m.call(*args) }
+    result = backend.run_command("ruby -e 'STDOUT.puts \"stdout\"; STDERR.puts \"stderr\"'")
+    expect(result.stdout.chomp).to eq('stdout')
+    expect(result.stderr.chomp).to eq('stderr')
+  end
+end
+
+context 'when executed process has exited between reading stdout and stderr,' do
+  let(:backend) { Specinfra::Backend::Exec.new }
+
+  it 'can consume stdout and stderr from buffer' do
+    backend.stdout_handler = proc { |o| sleep 1 }
+    result = backend.run_command("ruby -e 'STDOUT.puts \"stdout\"; STDOUT.close; STDERR.puts \"stderr\"'")
+    expect(result.stdout.chomp).to eq('stdout')
+    expect(result.stderr.chomp).to eq('stderr')
+  end
+end
+
+context 'Output of stderr_handler' do
+  let(:backend) { Specinfra::Backend::Exec.new }
+  subject(:stderr) do
+    allow(IO).to receive(:select).and_wrap_original { |m, *args| sleep 1; m.call(*args) }
+    err = ''
+    backend.stderr_handler = proc { |e| err += e }
+    backend.run_command('echo foo 1>&2')
+    err
+  end
+
+  it { expect(stderr).to eq "foo\n" }
+end


### PR DESCRIPTION
`Backend::Exec` can't get entire stdout or stderr due to race condition between specinfra and spawned process.
This PR will consume remained data in buffer.

These specs include `sleep 1` to raise error surely.
But, these specs will fail without `sleep` very rarely(below 1/100 on my environment)

IMHO, original code remain data cause following scenario.

1. child process write stdout and close it
2. child process write stderr
3. specinfra read from stdout and catch `EOFError`
4. exit thread although some text remain in buffer of stderr 