### PR TITLE
Support fluentd plugin installed check command

### DIFF
--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -7,6 +7,13 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
       cmd
     end
 
+    def check_is_installed_by_td_agent_gem(name, version=nil)
+      regexp = "^#{name}"
+      cmd = "/usr/sbin/td-agent-gem list --local | grep -iw -- #{escape(regexp)}"
+      cmd = %Q!#{cmd} | grep -w -- "[( ]#{escape(version)}[,)]"! if version
+      cmd
+    end
+
     def check_is_installed_by_rvm(name, version=nil)
       regexp = "^#{name}"
       cmd = "rvm list strings | grep -iw -- #{escape(regexp)}"

--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -1,17 +1,11 @@
 class Specinfra::Command::Base::Package < Specinfra::Command::Base
   class << self
     def check_is_installed_by_gem(name, version=nil)
-      regexp = "^#{name}"
-      cmd = "gem list --local | grep -iw -- #{escape(regexp)}"
-      cmd = %Q!#{cmd} | grep -w -- "[( ]#{escape(version)}[,)]"! if version
-      cmd
+      gem_installed_command("gem", name, version)
     end
 
     def check_is_installed_by_td_agent_gem(name, version=nil)
-      regexp = "^#{name}"
-      cmd = "/usr/sbin/td-agent-gem list --local | grep -iw -- #{escape(regexp)}"
-      cmd = %Q!#{cmd} | grep -w -- "[( ]#{escape(version)}[,)]"! if version
-      cmd
+      gem_installed_command("/usr/sbin/td-agent-gem", name, version)
     end
 
     def check_is_installed_by_rvm(name, version=nil)
@@ -52,6 +46,15 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
       regexp = "^#{name}"
       cmd = "cpan -l | grep -iw -- #{escape(regexp)}"
       cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
+      cmd
+    end
+
+    private
+
+    def gem_installed_command(gem_binary, name, version=nil)
+      regexp = "^#{name}"
+      cmd = "#{gem_binary} list --local | grep -iw -- #{escape(regexp)}"
+      cmd = %Q!#{cmd} | grep -w -- "[( ]#{escape(version)}[,)]"! if version
       cmd
     end
   end

--- a/spec/command/base/package_spec.rb
+++ b/spec/command/base/package_spec.rb
@@ -6,6 +6,10 @@ describe get_command(:check_package_is_installed_by_gem, 'serverspec', '2.0.0') 
   it { should eq 'gem list --local | grep -iw -- \\^serverspec | grep -w -- "[( ]2.0.0[,)]"' }
 end
 
+describe get_command(:check_package_is_installed_by_td_agent_gem, 'fluent-plugin-forest', '0.3.0') do
+  it { should eq '/usr/sbin/td-agent-gem list --local | grep -iw -- \\^fluent-plugin-forest | grep -w -- "[( ]0.3.0[,)]"' }
+end
+
 describe get_command(:check_package_is_installed_by_rvm, 'rbx', '2.4.1') do
   it { should eq 'rvm list strings | grep -iw -- \\^rbx | grep -w -- 2.4.1' }
 end


### PR DESCRIPTION
Check for whether fluentd plugin is installed by td-agent-gem

# Example
```ruby
describe package("fluent-plugin-forest") do
  it { should be_installed.by("td_agent_gem").with_version("0.3.0") }
end
```
