### PR TITLE
Revert gemspec logic to allow install on Ruby 1.9.3

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-scp"
-  spec.add_runtime_dependency "net-ssh", ">= 2.7", "< 4.0"
+  spec.add_runtime_dependency "net-ssh", ">= 2.7", (RUBY_VERSION >= "2.0" ? "< 4.0" : "< 2.10")
   spec.add_runtime_dependency "net-telnet"
   spec.add_runtime_dependency "sfl"
 


### PR DESCRIPTION
- Logic was remove that isolated the net-ssh to 2.9.x for Ruby version 1.9.3
  removing this now requires downstream users to explicity install net-ssh 2.9.4