### PR TITLE
Use cut instead of awk

### DIFF
--- a/lib/specinfra/command/base/user.rb
+++ b/lib/specinfra/command/base/user.rb
@@ -5,7 +5,7 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
     end
 
     def check_belongs_to_group(user, group)
-      "id #{escape(user)} | sed 's/ context=.*//g' |awk -F= '{print $4}' | grep -- #{escape(group)}"
+      "id #{escape(user)} | sed 's/ context=.*//g' | cut -f 4 -d '=' | grep -- #{escape(group)}"
     end
 
     def check_belongs_to_primary_group(user, group)
@@ -31,11 +31,11 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
     end
 
     def get_minimum_days_between_password_change(user)
-      "chage -l #{escape(user)} | grep '^Minimum.*:' | awk -F ': ' '{print $2}'"
+      "chage -l #{escape(user)} | grep '^Minimum.*:' | cut -f 2 -d ': '"
     end
 
     def get_maximum_days_between_password_change(user)
-      "chage -l #{escape(user)} | grep '^Maximum.*:' | awk -F ': ' '{print $2}'"
+      "chage -l #{escape(user)} | grep '^Maximum.*:' | cut -f 2 -d ': '"
     end
 
     def get_uid(user)
@@ -47,7 +47,7 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
     end
 
     def get_home_directory(user)
-      "getent passwd #{escape(user)} | awk -F: '{ print $6 }'"
+      "getent passwd #{escape(user)} | cut -f 6 -d ':'"
     end
 
     def get_login_shell(user)
@@ -88,7 +88,7 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
     end
 
     def get_encrypted_password(user)
-      "getent shadow #{escape(user)} | awk -F: '{ print $2 }'"
+      "getent shadow #{escape(user)} | cut -f 2 -d ':'"
     end
   end
 end

--- a/spec/command/base/user_spec.rb
+++ b/spec/command/base/user_spec.rb
@@ -11,7 +11,7 @@ describe get_command(:get_user_gid, 'foo') do
 end
 
 describe get_command(:get_user_home_directory, 'foo') do
-  it { should eq "getent passwd foo | awk -F: '{ print $6 }'" }
+  it { should eq "getent passwd foo | cut -f 6 -d ':'" }
 end
 
 describe get_command(:update_user_home_directory, 'user', 'dir') do
@@ -35,7 +35,7 @@ describe get_command(:update_user_encrypted_password, 'foo', 'xxxxxxxx') do
 end
 
 describe get_command(:get_user_encrypted_password, 'foo') do
-  it { should eq "getent shadow foo | awk -F: '{ print $2 }'" }
+  it { should eq "getent shadow foo | cut -f 2 -d ':'" }
 end
 
 describe get_command(:check_user_has_login_shell, 'foo', '/bin/sh') do
@@ -43,11 +43,11 @@ describe get_command(:check_user_has_login_shell, 'foo', '/bin/sh') do
 end
 
 describe get_command(:get_user_minimum_days_between_password_change, 'foo') do
-  it { should eq "chage -l foo | grep '^Minimum.*:' | awk -F ': ' '{print $2}'" }
+  it { should eq "chage -l foo | grep '^Minimum.*:' | cut -f 2 -d ': '" }
 end
 
 describe get_command(:get_user_maximum_days_between_password_change, 'foo') do
-  it { should eq "chage -l foo | grep '^Maximum.*:' | awk -F ': ' '{print $2}'" }
+  it { should eq "chage -l foo | grep '^Maximum.*:' | cut -f 2 -d ': '" }
 end
 
 describe get_command(:get_user_login_shell, 'foo') do


### PR DESCRIPTION
If the previous command runs like following, it doesn't work as expected
because '$6' is expanded by `sudo -i`.
It can be avoided by removing `-i` or something other way, but in thi
case using cut seems simplest.

> sudo -H -u ubuntu -i -- /bin/bash -i -c cd\ \&\&\ getent\ passwd\ ubuntu\ \|\ awk\ -F:\ \'\{\ print\ \$6\ \}\'