### PR TITLE
Use sed instead of grep and cut

### DIFF
--- a/lib/specinfra/command/base/user.rb
+++ b/lib/specinfra/command/base/user.rb
@@ -31,11 +31,11 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
     end
 
     def get_minimum_days_between_password_change(user)
-      "chage -l #{escape(user)} | grep '^Minimum.*:' | cut -f 2 -d ': '"
+      "chage -l #{escape(user)} | sed -n 's/^Minimum.*: //p'"
     end
 
     def get_maximum_days_between_password_change(user)
-      "chage -l #{escape(user)} | grep '^Maximum.*:' | cut -f 2 -d ': '"
+      "chage -l #{escape(user)} | sed -n 's/^Maximum.*: //p'"
     end
 
     def get_uid(user)

--- a/spec/command/base/user_spec.rb
+++ b/spec/command/base/user_spec.rb
@@ -43,11 +43,11 @@ describe get_command(:check_user_has_login_shell, 'foo', '/bin/sh') do
 end
 
 describe get_command(:get_user_minimum_days_between_password_change, 'foo') do
-  it { should eq "chage -l foo | grep '^Minimum.*:' | cut -f 2 -d ': '" }
+  it { should eq "chage -l foo | sed -n 's/^Minimum.*: //p'" }
 end
 
 describe get_command(:get_user_maximum_days_between_password_change, 'foo') do
-  it { should eq "chage -l foo | grep '^Maximum.*:' | cut -f 2 -d ': '" }
+  it { should eq "chage -l foo | sed -n 's/^Maximum.*: //p'" }
 end
 
 describe get_command(:get_user_login_shell, 'foo') do


### PR DESCRIPTION
`cut -d SEP` gets only one character, not a string.
Pached by @eban https://twitter.com/eban/status/733663069302218752