### PR TITLE
Add check that symlinks can be fully resolved to their real path

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -133,6 +133,10 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
       "readlink -e #{escape(link)}"
     end
 
+    def check_is_dereferenceable(link)
+      %Q|test -n "$(readlink -e #{escape(link)})"|
+    end
+
     def get_mtime(file)
       "stat -c %Y #{escape(file)}"
     end

--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -28,10 +28,6 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
       "test -L #{escape(file)}"
     end
 
-    def check_is_resolvable(file)
-       "readlink -e #{escape(file)}"
-    end
-
     def check_contains(file, expected_pattern)
       "#{check_contains_with_regexp(file, expected_pattern)} || #{check_contains_with_fixed_strings(file, expected_pattern)}"
     end
@@ -131,6 +127,10 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
 
     def get_link_target(link)
       "readlink #{escape(link)}"
+    end
+
+    def get_link_realpath(link)
+      "readlink -e #{escape(link)}"
     end
 
     def get_mtime(file)

--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -28,6 +28,10 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
       "test -L #{escape(file)}"
     end
 
+    def check_is_resolvable(file)
+       "readlink -e #{escape(file)}"
+    end
+
     def check_contains(file, expected_pattern)
       "#{check_contains_with_regexp(file, expected_pattern)} || #{check_contains_with_fixed_strings(file, expected_pattern)}"
     end

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -98,6 +98,10 @@ describe get_command(:get_file_link_realpath, '/tmp') do
   it { should eq 'readlink -e /tmp' }
 end
 
+describe get_command(:check_file_is_dereferenceable, '/tmp') do
+  it { should eq 'test -n "$(readlink -e /tmp)"' }
+end
+
 describe get_command(:check_file_exists, '/tmp') do
   it { should eq 'test -e /tmp' }
 end

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -78,6 +78,10 @@ describe get_command(:check_file_is_link, '/tmp') do
   it { should eq 'test -L /tmp' }
 end
 
+describe get_command(:check_file_is_resolvable, '/tmp') do
+  it { should eq 'readlink -e /tmp' }
+end
+
 describe get_command(:check_file_is_pipe, '/tmp') do
   it { should eq 'test -p /tmp' }
 end

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -78,10 +78,6 @@ describe get_command(:check_file_is_link, '/tmp') do
   it { should eq 'test -L /tmp' }
 end
 
-describe get_command(:check_file_is_resolvable, '/tmp') do
-  it { should eq 'readlink -e /tmp' }
-end
-
 describe get_command(:check_file_is_pipe, '/tmp') do
   it { should eq 'test -p /tmp' }
 end
@@ -96,6 +92,10 @@ end
 
 describe get_command(:get_file_link_target, '/tmp') do
   it { should eq 'readlink /tmp' }
+end
+
+describe get_command(:get_file_link_realpath, '/tmp') do
+  it { should eq 'readlink -e /tmp' }
 end
 
 describe get_command(:check_file_exists, '/tmp') do


### PR DESCRIPTION
To check that the real path of a symlink is completely resolvable. To test when there are multiple levels of symlinks.