### PR TITLE
host_inventory: use systemd-detect-virt for virtualization detection

### DIFF
--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -19,7 +19,13 @@ module Specinfra
         ret = backend.run_command(cmd)
         if ret.exit_status == 0
            res[:system] = parse_system_product_name(ret.stdout)   
-        end 
+           return res
+        end
+
+        ret = backend.run_command('systemd-detect-virt')
+        if ret.success?
+          res[:system] = parse_systemd_detect_virt_output(ret.stdout)
+        end
 
         res 
       end 
@@ -38,6 +44,17 @@ module Specinfra
             nil
         end
         product_name
+      end
+
+      def parse_systemd_detect_virt_output(ret)
+        detected = ret.strip
+
+        case detected
+        when 'vmware', 'kvm'
+          detected
+        when 'oracle'
+          'vbox'
+        end
       end
 
     end


### PR DESCRIPTION
[systemd-detect-virt](https://www.freedesktop.org/software/systemd/man/systemd-detect-virt.html) is available with systemd v183 and later.