### PR TITLE
Isolate specs so the whole suite can be run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,6 @@ if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   # net-ssh 3.x dropped Ruby 1.8 and 1.9 support.
   gem 'net-ssh', '~> 2.7'
 end
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.2.3')
+  gem 'listen', '< 3.1'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,22 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in specinfra.gemspec
 gemspec
 
-if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+ruby_version = Gem::Version.new(RUBY_VERSION.dup)
+if ruby_version < Gem::Version.new('2.0.0')
   # net-ssh 3.x dropped Ruby 1.8 and 1.9 support.
   gem 'net-ssh', '~> 2.7'
 end
-if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.2.3')
+if ruby_version < Gem::Version.new('1.9.3')
+  # listen 2.0 dropped Ruby 1.8 support
+  gem 'listen', '< 2.0'
+  gem 'guard-rspec', '< 4.0'
+  gem 'guard', '< 2.0'
+  # hitimes 1.2.3 dropped Ruby 1.8 support
+  gem 'hitimes', '< 1.2.3'
+elsif ruby_version < Gem::Version.new('2.0.0')
+  # listen 3.0 dropped Ruby 1.8 and 1.9 support
+  gem 'listen', '< 3.0'
+elsif ruby_version < Gem::Version.new('2.2.3')
+  # listen 3.1 dropped support for Ruby 2.1 and lower
   gem 'listen', '< 3.1'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,7 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard :rspec do
+guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch('spec/spec_helper.rb')  { 'spec' }
 end

--- a/lib/specinfra/ext/class.rb
+++ b/lib/specinfra/ext/class.rb
@@ -2,6 +2,7 @@ class Class
   def subclasses
     result = []
     ObjectSpace.each_object(Class) do |k|
+      next if k.singleton_class?
       result << k if k < self
     end
     result

--- a/lib/specinfra/ext/class.rb
+++ b/lib/specinfra/ext/class.rb
@@ -2,7 +2,7 @@ class Class
   def subclasses
     result = []
     ObjectSpace.each_object(Class) do |k|
-      next if k.singleton_class?
+      next if k.name.nil?
       result << k if k < self
     end
     result

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Specinfra::Backend::Exec do
+  before :all do
+    set :backend, :exec
+  end
+
   describe '#build_command' do
     context 'with simple command' do
       it 'should escape spaces' do
@@ -108,6 +112,7 @@ describe 'os' do
   before do
     # clear os information cache
     property[:os_by_host] = {}
+    property[:os] = nil
   end
 
   context 'test ubuntu with lsb_release command' do
@@ -131,9 +136,6 @@ describe 'os' do
   end
 
   context 'test ubuntu with /etc/lsb-release' do
-    before do
-      property[:os] = nil
-    end
     subject { os }
     it do
       expect(Specinfra.backend).to receive(:run_command).at_least(1).times do |args|
@@ -159,9 +161,6 @@ EOF
   end
 
   context 'test debian (no lsb_release or lsb-release)' do
-    before do
-      property[:os] = nil
-    end
     subject { os }
     it do
       expect(Specinfra.backend).to receive(:run_command).at_least(1).times do |args|

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -116,9 +116,8 @@ describe 'os' do
   end
 
   context 'test ubuntu with lsb_release command' do
-    subject { os }
-    it do
-      expect(Specinfra.backend).to receive(:run_command).at_least(1).times do |args|
+    before do
+      allow(Specinfra.backend).to receive(:run_command) do |args|
         if ['ls /etc/debian_version', 'lsb_release -ir'].include? args
           double(
             :run_command_response,
@@ -131,14 +130,17 @@ describe 'os' do
           double :run_command_response, :success? => false, :stdout => nil
         end
       end
+    end
+    subject! { os }
+    it do
+      expect(Specinfra.backend).to have_received(:run_command).at_least(1).times
       should eq({:family => 'ubuntu', :release => '12.04', :arch => 'x86_64' })
     end
   end
 
   context 'test ubuntu with /etc/lsb-release' do
-    subject { os }
-    it do
-      expect(Specinfra.backend).to receive(:run_command).at_least(1).times do |args|
+    before do
+      allow(Specinfra.backend).to receive(:run_command) do |args|
         if ['ls /etc/debian_version', 'cat /etc/lsb-release'].include? args
           double(
             :run_command_response,
@@ -156,14 +158,17 @@ EOF
           double :run_command_response, :success? => false, :stdout => nil
         end
       end
+    end
+    subject! { os }
+    it do
+      expect(Specinfra.backend).to have_received(:run_command).at_least(1).times
       should eq({:family => 'ubuntu', :release => '12.04', :arch => 'x86_64' })
     end
   end
 
   context 'test debian (no lsb_release or lsb-release)' do
-    subject { os }
-    it do
-      expect(Specinfra.backend).to receive(:run_command).at_least(1).times do |args|
+    before do
+      allow(Specinfra.backend).to receive(:run_command) do |args|
         if args == 'ls /etc/debian_version'
           double :run_command_response, :success? => true, :stdout => nil
         elsif args == 'uname -m'
@@ -172,6 +177,10 @@ EOF
           double :run_command_response, :success? => false, :stdout => nil
         end
       end
+    end
+    subject! { os }
+    it do
+      expect(Specinfra.backend).to have_received(:run_command).at_least(1).times
       should eq({:family => 'debian', :release => nil, :arch => 'x86_64' })
     end
   end

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -113,6 +113,7 @@ describe 'os' do
     # clear os information cache
     property[:os_by_host] = {}
     property[:os] = nil
+    Specinfra.configuration.instance_variable_set(:@os, nil)
   end
 
   context 'test ubuntu with lsb_release command' do

--- a/spec/backend/exec/child_process_spec.rb
+++ b/spec/backend/exec/child_process_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 context "when executed process launches child process like a daemon, and the daemon doesn't close stdout,err" do
+  before :all do
+    set :backend, :exec
+  end
+
   subject(:result) { Specinfra::Runner.run_command("ruby -e 'pid = fork { sleep 10; puts :bye }; Process.detach(pid); puts pid'") }
 
   it "doesn't block" do

--- a/spec/backend/exec/consume_exited_process_spec.rb
+++ b/spec/backend/exec/consume_exited_process_spec.rb
@@ -1,36 +1,42 @@
 require 'spec_helper'
 
-context 'when executed process had exited before read stdout and stderr,' do
-  let(:backend) { Specinfra::Backend::Exec.new }
-
-  it 'can consume stdout and stderr from buffer' do
-    allow(IO).to receive(:select).and_wrap_original { |m, *args| sleep 1; m.call(*args) }
-    result = backend.run_command("ruby -e 'STDOUT.puts \"stdout\"; STDERR.puts \"stderr\"'")
-    expect(result.stdout.chomp).to eq('stdout')
-    expect(result.stderr.chomp).to eq('stderr')
-  end
-end
-
-context 'when executed process has exited between reading stdout and stderr,' do
-  let(:backend) { Specinfra::Backend::Exec.new }
-
-  it 'can consume stdout and stderr from buffer' do
-    backend.stdout_handler = proc { |o| sleep 1 }
-    result = backend.run_command("ruby -e 'STDOUT.puts \"stdout\"; STDOUT.close; STDERR.puts \"stderr\"'")
-    expect(result.stdout.chomp).to eq('stdout')
-    expect(result.stderr.chomp).to eq('stderr')
-  end
-end
-
-context 'Output of stderr_handler' do
-  let(:backend) { Specinfra::Backend::Exec.new }
-  subject(:stderr) do
-    allow(IO).to receive(:select).and_wrap_original { |m, *args| sleep 1; m.call(*args) }
-    err = ''
-    backend.stderr_handler = proc { |e| err += e }
-    backend.run_command('echo foo 1>&2')
-    err
+RSpec.describe 'exec backend' do
+  before :all do
+    set :backend, :exec
   end
 
-  it { expect(stderr).to eq "foo\n" }
+  context 'when executed process had exited before read stdout and stderr,' do
+    let(:backend) { Specinfra::Backend::Exec.new }
+
+    it 'can consume stdout and stderr from buffer' do
+      allow(IO).to receive(:select).and_wrap_original { |m, *args| sleep 1; m.call(*args) }
+      result = backend.run_command("ruby -e 'STDOUT.puts \"stdout\"; STDERR.puts \"stderr\"'")
+      expect(result.stdout.chomp).to eq('stdout')
+      expect(result.stderr.chomp).to eq('stderr')
+    end
+  end
+
+  context 'when executed process has exited between reading stdout and stderr,' do
+    let(:backend) { Specinfra::Backend::Exec.new }
+
+    it 'can consume stdout and stderr from buffer' do
+      backend.stdout_handler = proc { |o| sleep 1 }
+      result = backend.run_command("ruby -e 'STDOUT.puts \"stdout\"; STDOUT.close; STDERR.puts \"stderr\"'")
+      expect(result.stdout.chomp).to eq('stdout')
+      expect(result.stderr.chomp).to eq('stderr')
+    end
+  end
+
+  context 'Output of stderr_handler' do
+    let(:backend) { Specinfra::Backend::Exec.new }
+    subject(:stderr) do
+      allow(IO).to receive(:select).and_wrap_original { |m, *args| sleep 1; m.call(*args) }
+      err = ''
+      backend.stderr_handler = proc { |e| err += e }
+      backend.run_command('echo foo 1>&2')
+      err
+    end
+
+    it { expect(stderr).to eq "foo\n" }
+  end
 end

--- a/spec/backend/exec/env_spec.rb
+++ b/spec/backend/exec/env_spec.rb
@@ -1,11 +1,15 @@
 require 'spec_helper'
 
+set :backend, :exec
+
 describe Specinfra.backend.run_command('echo $LANG').stdout.strip do
   it { should eq 'C' }
 end
 
 describe do
   before do
+    set :backend, :exec
+
     ENV['LANG'] = 'C'
     set :env, :LANG => 'ja_JP.UTF-8'
   end

--- a/spec/backend/exec/read_noblock_spec.rb
+++ b/spec/backend/exec/read_noblock_spec.rb
@@ -38,6 +38,10 @@ shared_examples "IO checks" do
 end
 
 describe "buffer overflow problem" do
+    before :all do
+        set :backend, :exec
+    end
+
     context "with small output amount" do
         let (:max) { 10 }
         include_examples "IO checks"

--- a/spec/backend/ssh/build_command_spec.rb
+++ b/spec/backend/ssh/build_command_spec.rb
@@ -1,14 +1,28 @@
 require 'spec_helper'
 
-set :backend, :ssh
-
 describe Specinfra::Backend::Ssh do
+  before(:all) do
+    set :backend, :ssh
+  end
+
+  after(:all) do
+    if Specinfra.configuration.instance_variable_defined?(:@ssh_options)
+      Specinfra.configuration.remove_instance_variable(:@ssh_options)
+    end
+  end
+
   describe '#build_command' do
     context 'with root user' do 
       before do
         RSpec.configure do |c|
           set :ssh_options, :user => 'root'
           c.ssh = double(:ssh, Specinfra.configuration.ssh_options)
+        end
+      end
+
+      after do
+        RSpec.configure do |c|
+          c.ssh = nil
         end
       end
 
@@ -26,6 +40,12 @@ describe Specinfra::Backend::Ssh do
         RSpec.configure do |c|
           set :ssh_options, :user => 'foo'
           c.ssh = double(:ssh, Specinfra.configuration.ssh_options)
+        end
+      end
+
+      after do
+        RSpec.configure do |c|
+          c.ssh = nil
         end
       end
 
@@ -49,6 +69,7 @@ describe Specinfra::Backend::Ssh do
 
       after do
         RSpec.configure do |c|
+          c.ssh = nil
           c.sudo_path = nil
         end
       end
@@ -73,6 +94,7 @@ describe Specinfra::Backend::Ssh do
 
       after do
         RSpec.configure do |c|
+          c.ssh = nil
           c.disable_sudo = false
         end
       end
@@ -97,6 +119,7 @@ describe Specinfra::Backend::Ssh do
 
       after do
         RSpec.configure do |c|
+          c.ssh = nil
           c.sudo_options = nil
         end
       end

--- a/spec/backend/ssh/build_command_spec.rb
+++ b/spec/backend/ssh/build_command_spec.rb
@@ -7,7 +7,7 @@ describe Specinfra::Backend::Ssh do
 
   after(:all) do
     if Specinfra.configuration.instance_variable_defined?(:@ssh_options)
-      Specinfra.configuration.remove_instance_variable(:@ssh_options)
+      Specinfra.configuration.instance_variable_set(:@ssh_options, nil)
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,14 +1,30 @@
 require 'spec_helper'
 
-RSpec.configure do |c|
-  c.path = 'foo'
-end
+describe 'RSpec.configuration.path' do
+  before do
+    RSpec.configure do |c|
+      c.path = 'foo'
+    end
+  end
 
-describe RSpec.configuration.path do
+  after do
+    RSpec.configure do |c|
+      c.path = nil
+    end
+  end
+
+  subject { RSpec.configuration.path }
+
   it { should eq Specinfra.configuration.path }
 end
 
 Specinfra.configuration.os = 'foo'
 describe Specinfra.configuration.os do
   it { should eq 'foo' }
+end
+
+Specinfra.configuration.remove_instance_variable(:@os)
+RSpec.configuration.os = nil
+describe Specinfra.configuration.os do
+  it { should be_nil }
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -23,7 +23,7 @@ describe Specinfra.configuration.os do
   it { should eq 'foo' }
 end
 
-Specinfra.configuration.remove_instance_variable(:@os)
+Specinfra.configuration.instance_variable_set(:@os, nil)
 RSpec.configuration.os = nil
 describe Specinfra.configuration.os do
   it { should be_nil }

--- a/spec/helper/detect_os/darwin_spec.rb
+++ b/spec/helper/detect_os/darwin_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'specinfra/helper/detect_os/darwin'
 
 describe Specinfra::Helper::DetectOs::Darwin do
-  darwin = Specinfra::Helper::DetectOs::Darwin.new(:exec)
+  darwin = Specinfra::Helper::DetectOs::Darwin.new(Specinfra.backend)
   it 'Should return darwin 13.4.0 when Mac OS X 10.9.5 (Mavericks) is installed.' do
     allow(darwin).to receive(:run_command) {
       CommandResult.new(:stdout => 'Darwin 13.4.0', :exit_status => 0)

--- a/spec/helper/os_spec.rb
+++ b/spec/helper/os_spec.rb
@@ -1,58 +1,60 @@
 require 'spec_helper'
 
-def set_stub_chain(keys, value)
-    allow(Specinfra).to receive_message_chain([:configuration, keys].flatten).and_return(value)
-end
-
-describe 'no ssh connection without cache' do
-  before do
-    property[:os] = nil
-    set_stub_chain(:ssh, nil)
-    set_stub_chain(:ssh_options, nil)
-    set_stub_chain(:host, 'localhost')
-    set_stub_chain(:os, :family => 'redhat')
+RSpec.describe 'os', :order => :defined do
+  def set_stub_chain(keys, value)
+      allow(Specinfra).to receive_message_chain([:configuration, keys].flatten).and_return(value)
   end
 
-  it { expect(os[:family]).to eq 'redhat' }
-end
+  describe 'no ssh connection without cache' do
+    before do
+      property[:os] = nil
+      set_stub_chain(:ssh, nil)
+      set_stub_chain(:ssh_options, nil)
+      set_stub_chain(:host, 'localhost')
+      set_stub_chain(:os, :family => 'redhat')
+    end
 
-describe 'no ssh connection with cache' do
-  it { expect(property[:os]).to eq(:family => 'redhat') }
-end
-
-describe 'ssh_options without cache' do
-  before do
-    property[:os] = nil
-    set_stub_chain(:ssh, nil)
-    set_stub_chain(:ssh_options, :port => 22)
-    set_stub_chain(:host, 'localhost')
-    set_stub_chain(:os, :family => 'ubuntu')
+    it { expect(os[:family]).to eq 'redhat' }
   end
 
-  it { expect(os[:family]).to eq 'ubuntu' }
-end
-
-describe 'ssh_options with cache' do
-  it { expect(property[:os]).to eq(:family => 'ubuntu') }
-end
-
-describe 'ssh_connection without cache' do
-  before do
-    property[:os] = nil
-    set_stub_chain([:ssh, :host], 'localhost')
-    set_stub_chain([:ssh, :options], :port => 2222)
-    set_stub_chain(:os, :family => 'nixos')
+  describe 'no ssh connection with cache' do
+    it { expect(property[:os]).to eq(:family => 'redhat') }
   end
 
-  it { expect(os[:family]).to eq 'nixos' }
-end
+  describe 'ssh_options without cache' do
+    before do
+      property[:os] = nil
+      set_stub_chain(:ssh, nil)
+      set_stub_chain(:ssh_options, :port => 22)
+      set_stub_chain(:host, 'localhost')
+      set_stub_chain(:os, :family => 'ubuntu')
+    end
 
-describe 'ssh_connection wit cache' do
-  before do
-    set_stub_chain([:ssh, :host], 'localhost')
-    set_stub_chain([:ssh, :options], :port => 2222)
-    set_stub_chain(:os, :family => 'nixos')
+    it { expect(os[:family]).to eq 'ubuntu' }
   end
 
-  it { expect(property[:os]).to eq(:family => 'nixos') }
+  describe 'ssh_options with cache' do
+    it { expect(property[:os]).to eq(:family => 'ubuntu') }
+  end
+
+  describe 'ssh_connection without cache' do
+    before do
+      property[:os] = nil
+      set_stub_chain([:ssh, :host], 'localhost')
+      set_stub_chain([:ssh, :options], :port => 2222)
+      set_stub_chain(:os, :family => 'nixos')
+    end
+
+    it { expect(os[:family]).to eq 'nixos' }
+  end
+
+  describe 'ssh_connection with cache' do
+    before do
+      set_stub_chain([:ssh, :host], 'localhost')
+      set_stub_chain([:ssh, :options], :port => 2222)
+      set_stub_chain(:os, :family => 'nixos')
+    end
+
+    it { expect(property[:os]).to eq(:family => 'nixos') }
+  end
 end

--- a/spec/host_inventory/linux/virtualization_spec.rb
+++ b/spec/host_inventory/linux/virtualization_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
-set :os, { :family => 'linux' } 
-
 describe Specinfra::HostInventory::Virtualization do
+  before :all do
+    set :os, { :family => 'linux' }
+  end
+
   virt = Specinfra::HostInventory::Virtualization.new(host_inventory) 
   let(:host_inventory) { nil }
   it 'Docker Image should return :system => "docker"' do

--- a/spec/host_inventory/openbsd/virtualization_spec.rb
+++ b/spec/host_inventory/openbsd/virtualization_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
-set :os, { :family => 'openbsd' } 
-
 describe Specinfra::HostInventory::Virtualization do
+  before :all do
+    set :os, { :family => 'openbsd' }
+  end
+
   virt = Specinfra::HostInventory::Virtualization.new(host_inventory) 
 
   let(:host_inventory) { nil }

--- a/spec/host_inventory/solaris/virtualization_spec.rb
+++ b/spec/host_inventory/solaris/virtualization_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
-set :os, { :family => 'solaris' } 
-
 describe Specinfra::HostInventory::Virtualization do
+  before :all do
+    set :os, { :family => 'solaris' }
+  end
+
   virt = Specinfra::HostInventory::Virtualization.new(host_inventory) 
 
   let(:host_inventory) { nil }

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.1.1"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "guard"
+  spec.add_development_dependency "guard-rspec"
 end


### PR DESCRIPTION
It is more convenient to be able to run the specs with Guard and rspec rather
than relying on the separation of specs through rake. This PR handles setting / resetting global configurations around spec files to reduce the coupling between spec files.

I have tested running the spec suite in random order and in particular orders that failed before. E.g. running `rspec spec/backend/ssh spec/backend/exec` to show up global configurations that persist between different specs and cause each other to break.

NOTE: with the specs that are using an implicit subject from the describe group, it is not possible to use RSpec before / after hooks to set global configuration.