### PR TITLE
host_inventory: use kenv to get the system product name on FreeBSD

### DIFF
--- a/lib/specinfra/command/freebsd/base/inventory.rb
+++ b/lib/specinfra/command/freebsd/base/inventory.rb
@@ -24,5 +24,9 @@ class Specinfra::Command::Freebsd::Base::Inventory < Specinfra::Command::Base::I
     def get_filesystem
       'df -k'
     end
+
+    def get_system_product_name
+      'kenv smbios.system.product'
+    end
   end
 end


### PR DESCRIPTION
On FreeBSD, some of the SMBIOS information exported from the kernel are available through [kenv](https://www.freebsd.org/cgi/man.cgi?kenv(1)).