### PR TITLE
[Bug report] when hocon is loaded specinfra breaks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,5 @@ elsif ruby_version < Gem::Version.new('2.2.3')
   # listen 3.1 dropped support for Ruby 2.1 and lower
   gem 'listen', '< 3.1'
 end
+
+gem 'hocon'

--- a/non-working.rb
+++ b/non-working.rb
@@ -1,0 +1,6 @@
+require 'hocon'
+
+ObjectSpace.each_object(Class) { |k| puts k.name }
+
+# ArgumentError: wrong number of arguments (0 for 1)
+# from /home/chem/.gem/ruby/gems/hocon-0.9.5/lib/hocon/impl/token_type.rb:24:in `name'

--- a/working.rb
+++ b/working.rb
@@ -1,0 +1,1 @@
+ObjectSpace.each_object(Class) { |k| puts k.name }


### PR DESCRIPTION
hocon module which is use by puppetlab beaker, has a name class
definition which takes one argument:
https://github.com/puppetlabs/ruby-hocon/blob/master/lib/hocon/impl/token_type.rb#L24

This patch
https://github.com/mizzy/specinfra/commit/8d686d505dc9df6338e70b98ebadf4bec2bacd6d
changed the way module are loaded in a way that makes the module breaks
with this error message:

```
Hocon::Impl::Token
ArgumentError: wrong number of arguments (0 for 1)
from /home/chem/.gem/ruby/gems/hocon-0.9.5/lib/hocon/impl/token_type.rb:24:in `name'
```

This can be seen in the OpenStack CI
http://logs.openstack.org/07/329807/4/check/gate-puppet-keystone-puppet-beaker-rspec-centos-7/f6d4794/console.html#_2016-06-20_11_46_00_201579