### PR TITLE
pip and gem check_is_installed false successes

### DIFF
--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -36,7 +36,7 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
     end
 
     def check_is_installed_by_pip(name, version=nil)
-      regexp = "^#{name}"
+      regexp = "^#{name} "
       cmd = "pip list | grep -iw -- #{escape(regexp)}"
       cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
       cmd
@@ -52,7 +52,7 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
     private
 
     def gem_installed_command(gem_binary, name, version=nil)
-      regexp = "^#{name}"
+      regexp = "^#{name} "
       cmd = "#{gem_binary} list --local | grep -iw -- #{escape(regexp)}"
       cmd = %Q!#{cmd} | grep -w -- "[( ]#{escape(version)}[,)]"! if version
       cmd

--- a/spec/command/base/package_spec.rb
+++ b/spec/command/base/package_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 set :os, { :family => nil }
 
 describe get_command(:check_package_is_installed_by_gem, 'serverspec', '2.0.0') do
-  it { should eq 'gem list --local | grep -iw -- \\^serverspec | grep -w -- "[( ]2.0.0[,)]"' }
+  it { should eq 'gem list --local | grep -iw -- \\^serverspec\\  | grep -w -- "[( ]2.0.0[,)]"' }
 end
 
 describe get_command(:check_package_is_installed_by_td_agent_gem, 'fluent-plugin-forest', '0.3.0') do
-  it { should eq '/usr/sbin/td-agent-gem list --local | grep -iw -- \\^fluent-plugin-forest | grep -w -- "[( ]0.3.0[,)]"' }
+  it { should eq '/usr/sbin/td-agent-gem list --local | grep -iw -- \\^fluent-plugin-forest\\  | grep -w -- "[( ]0.3.0[,)]"' }
 end
 
 describe get_command(:check_package_is_installed_by_rvm, 'rbx', '2.4.1') do


### PR DESCRIPTION
I recently discovered when answering a question on StackOverflow that for a server with the following installed:

```
ansible-lint
puppet-lint
```

but not the following installed:

```
ansible
puppet
```

the following tests would still erroneously pass:

```ruby
describe package('ansible') do
  it { expect(subject).to be_installed.by('pip') }
end

describe package('puppet') do
  it { expect(subject).to be_installed.by('gem') }
end
```

This PR fixes those types of false successes.