### PR TITLE
Fix subclasses singleton_class check

### DIFF
--- a/lib/specinfra/ext/class.rb
+++ b/lib/specinfra/ext/class.rb
@@ -2,8 +2,9 @@ class Class
   def subclasses
     result = []
     ObjectSpace.each_object(Class) do |k|
-      next if k.name.nil?
-      result << k if k < self
+      next unless k < self
+      next if k.respond_to?(:singleton_class?) && k.singleton_class?
+      result << k
     end
     result
   end


### PR DESCRIPTION
Ruby <= 2.0 does not have Module#singleton_class? but also seems to not
include singleton classes in the object space. Thus we don't need to check for singleton_class subclasses to skip in Ruby <= 2.0.

Check `k < self` before checking for singleton class. This is the simpler check and limits us to checking for singleton_class amongst children of the class we care about (and generally have control over).

Fixes https://github.com/mizzy/specinfra/pull/558