### PR TITLE
Fixes singleton class check in subclasses

### DIFF
--- a/lib/specinfra/ext/class.rb
+++ b/lib/specinfra/ext/class.rb
@@ -2,7 +2,7 @@ class Class
   def subclasses
     result = []
     ObjectSpace.each_object(Class) do |k|
-      next if k.name.nil?
+      next unless k == k.ancestors.first #Skips if this is a singleton class
       result << k if k < self
     end
     result


### PR DESCRIPTION
@mizzy 

This is an alternative solution to #560 that also fixes the failure shown in #558 .

I believe in Ruby, all regular classes have themselves as `ancestors.first` except for singletons.

Thanks!