### PR TITLE
Add protocol options to darwin port listening check

### DIFF
--- a/lib/specinfra/command/darwin/base/port.rb
+++ b/lib/specinfra/command/darwin/base/port.rb
@@ -1,8 +1,19 @@
 class Specinfra::Command::Darwin::Base::Port < Specinfra::Command::Base::Port
   class << self
     def check_is_listening(port, options={})
-      regexp = ":#{port} "
-      "lsof -nP -iTCP -sTCP:LISTEN | grep -- #{escape(regexp)}"
+      regexp   = ":#{port} "
+      protocol = options[:protocol] || 'tcp'
+      protocol_options = case protocol
+      when 'tcp'
+        "-iTCP -sTCP:LISTEN"
+      when 'tcp6'
+        "-i6TCP -sTCP:LISTEN"
+      when 'udp'
+        "-iUDP"
+      when 'udp6'
+        "-i6UDP"
+      end
+      "lsof -nP #{protocol_options} | grep -- #{escape(regexp)}"
     end
   end
 end

--- a/spec/command/darwin/port_spec.rb
+++ b/spec/command/darwin/port_spec.rb
@@ -7,6 +7,6 @@ describe get_command(:check_port_is_listening, '80') do
   it { should eq 'lsof -nP -iTCP -sTCP:LISTEN | grep -- :80\ ' }
 end
 
-describe get_command(:check_port_is_listening, '80', protocol: 'udp') do
+describe get_command(:check_port_is_listening, '80', :protocol => 'udp') do
   it { should eq 'lsof -nP -iUDP | grep -- :80\ ' }
 end

--- a/spec/command/darwin/port_spec.rb
+++ b/spec/command/darwin/port_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'darwin'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq 'lsof -nP -iTCP -sTCP:LISTEN | grep -- :80\ ' }
+end
+
+describe get_command(:check_port_is_listening, '80', protocol: 'udp') do
+  it { should eq 'lsof -nP -iUDP | grep -- :80\ ' }
+end


### PR DESCRIPTION
Wanted to test if a `UDP` port was listening, but found that the `check_is_listening` for darwin doesn't handle the `:protocol` option.

Added the 4 different possibilities to the the `lsof -i` options, taken from the [man page](http://ss64.com/osx/lsof.html). Also note that `UDP` doesn't have a `LISTEN` state.

Thanks!