### PR TITLE
Ignore "system_user" option for user creation on FreeBSD.

### DIFF
--- a/lib/specinfra/command/freebsd/base/user.rb
+++ b/lib/specinfra/command/freebsd/base/user.rb
@@ -38,7 +38,6 @@ class Specinfra::Command::Freebsd::Base::User < Specinfra::Command::Base::User
       command << '-d' << escape(options[:home_directory]) if options[:home_directory]
       command << '-s' << escape(options[:shell])          if options[:shell]
       command << '-m' if options[:create_home]
-      command << '-r' if options[:system_user]
       command << '-u' << escape(options[:uid])            if options[:uid]
       if options[:password]
         command.concat(['&&', 'chpass', '-p', "\'#{options[:password]}\'", escape(user)])


### PR DESCRIPTION
On FreeBSD target, itamae(v1.9.8) "user resource"
failed with "system_user" option.

Cause:
pw(8) {useradd|user add} is NOTHING "-r" option
and create "system_user"(lower-range uid) option.

How to reproduce:

    $ cat > system_user.rb
    user "Create system user" do
      action :create
      username "testdaemon"
      system_user true
    end
    ^D

    $ itamae ssh -l debug -u USER -h FREEBSD_HOST system_user.rb
    or
    $ cd /path/to/vagrant/freebsd
    $ vagrant up
    $ itamae ssh -l debug --vagrant system_user.rb
    (snip)
    INFO :       user[Create system user] exist will change from 'false' to 'true'
    DEBUG :       Executing `id testdaemon`...
    DEBUG :         stdout | id: testdaemon: no such user
    DEBUG :         exited with 1
    DEBUG :       Executing `pw user add testdaemon -r`...
    DEBUG :         stdout | pw: illegal option -- r
    DEBUG :         stdout | pw: unknown switch
    ERROR :         Command `pw user add testdaemon -r` failed. (exit status: 64)
    ERROR :   user[Create system user] Failed.

Reference:
https://www.freebsd.org/cgi/man.cgi?pw(8)