### PR TITLE
Cask now uses 2 separate potential files locations

### DIFF
--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -48,7 +48,8 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
 
     def brew_cask_list
       # Since `brew cask list` is slow, directly check Caskroom directory
-      "ls -1 /opt/homebrew-cask/Caskroom/"
+      # Brew cask can install in multiple directories
+      "ls -1 /opt/homebrew-cask/Caskroom/ /usr/local/Caskroom"
     end
   end
 end


### PR DESCRIPTION
Problem
---
- Caskroom now uses 2 possible locations.
   - Deprecated, but still valid for older versions: /opt/homebrew-cask/Caskroom/
   - New: /usr/local/Caskroom
- Serverspec didn't handle the old one, now it should.

Simply check both, this should solve an issue where a cask is installed in the new location instead of the old one.