### PR TITLE
Issue: test parameters are not cleared between the individual test executions

### DIFF
--- a/test-argument-bug-explanation/port_spec.log
+++ b/test-argument-bug-explanation/port_spec.log
@@ -1,0 +1,45 @@
+# rake
+/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -I/Library/Ruby/Gems/2.0.0/gems/rspec-support-3.5.0/lib:/Library/Ruby/Gems/2.0.0/gems/rspec-core-3.5.0/lib /Library/Ruby/Gems/2.0.0/gems/rspec-core-3.5.0/exe/rspec --pattern spec/srv.example.com/\*_spec.rb
+
+Port "11111"
+  should be listening with udp6 (FAILED - 1)
+  should be listening on 192.168.2.2 with udp6 (FAILED - 2)
+  should be listening with udp6 (FAILED - 3)
+
+Failures:
+
+  1) Port "11111" should be listening with udp6
+     On host `srv.example.com'
+     Failure/Error: it { should be_listening.with('udp6') }
+       expected Port "11111" to be listening with udp6
+       sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*:11111\\\
+
+     # ./spec/srv.example.com/port_spec.rb:4:in `block (2 levels) in <top (required)>'
+
+  2) Port "11111" should be listening on 192.168.2.2 with udp6
+     On host `srv.example.com'
+     Failure/Error: it { should be_listening.on('192.168.2.2').with('udp6') }
+       expected Port "11111" to be listening on 192.168.2.2 with udp6
+       sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*\\\ 192.168.2.2:11111\\\
+
+     # ./spec/srv.example.com/port_spec.rb:5:in `block (2 levels) in <top (required)>'
+
+  3) Port "11111" should be listening with udp6
+     On host `srv.example.com'
+     Failure/Error: it { should be_listening.with('udp6') }
+       expected Port "11111" to be listening with udp6
+       sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*\\\ 192.168.2.2:11111\\\
+
+     # ./spec/srv.example.com/port_spec.rb:6:in `block (2 levels) in <top (required)>'
+
+Finished in 22.48 seconds (files took 0.4499 seconds to load)
+3 examples, 3 failures
+
+Failed examples:
+
+rspec ./spec/srv.example.com/port_spec.rb:4 # Port "11111" should be listening with udp6
+rspec ./spec/srv.example.com/port_spec.rb:5 # Port "11111" should be listening on 192.168.2.2 with udp6
+rspec ./spec/srv.example.com/port_spec.rb:6 # Port "11111" should be listening with udp6
+
+/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -I/Library/Ruby/Gems/2.0.0/gems/rspec-support-3.5.0/lib:/Library/Ruby/Gems/2.0.0/gems/rspec-core-3.5.0/lib /Library/Ruby/Gems/2.0.0/gems/rspec-core-3.5.0/exe/rspec --pattern spec/srv.example.com/\*_spec.rb failed
+#

--- a/test-argument-bug-explanation/port_spec.rb
+++ b/test-argument-bug-explanation/port_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe port(11111) do
+
+  # the test case below will execute:
+  #   sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*:11111\\\
+  it { should be_listening.with('udp6') }
+  
+  it { should be_listening.on('192.168.2.2').with('udp6') }
+
+  # the same test case below will execute:
+  #   sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*\\\ 192.168.2.2:11111\\\
+  it { should be_listening.with('udp6') }
+
+end

--- a/test-parameter-issue-explanation/port_spec.log
+++ b/test-parameter-issue-explanation/port_spec.log
@@ -1,0 +1,45 @@
+# rake
+/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -I/Library/Ruby/Gems/2.0.0/gems/rspec-support-3.5.0/lib:/Library/Ruby/Gems/2.0.0/gems/rspec-core-3.5.0/lib /Library/Ruby/Gems/2.0.0/gems/rspec-core-3.5.0/exe/rspec --pattern spec/srv.example.com/\*_spec.rb
+
+Port "11111"
+  should be listening with udp6 (FAILED - 1)
+  should be listening on 192.168.2.2 with udp6 (FAILED - 2)
+  should be listening with udp6 (FAILED - 3)
+
+Failures:
+
+  1) Port "11111" should be listening with udp6
+     On host `srv.example.com'
+     Failure/Error: it { should be_listening.with('udp6') }
+       expected Port "11111" to be listening with udp6
+       sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*:11111\\\
+
+     # ./spec/srv.example.com/port_spec.rb:4:in `block (2 levels) in <top (required)>'
+
+  2) Port "11111" should be listening on 192.168.2.2 with udp6
+     On host `srv.example.com'
+     Failure/Error: it { should be_listening.on('192.168.2.2').with('udp6') }
+       expected Port "11111" to be listening on 192.168.2.2 with udp6
+       sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*\\\ 192.168.2.2:11111\\\
+
+     # ./spec/srv.example.com/port_spec.rb:5:in `block (2 levels) in <top (required)>'
+
+  3) Port "11111" should be listening with udp6
+     On host `srv.example.com'
+     Failure/Error: it { should be_listening.with('udp6') }
+       expected Port "11111" to be listening with udp6
+       sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*\\\ 192.168.2.2:11111\\\
+
+     # ./spec/srv.example.com/port_spec.rb:6:in `block (2 levels) in <top (required)>'
+
+Finished in 22.48 seconds (files took 0.4499 seconds to load)
+3 examples, 3 failures
+
+Failed examples:
+
+rspec ./spec/srv.example.com/port_spec.rb:4 # Port "11111" should be listening with udp6
+rspec ./spec/srv.example.com/port_spec.rb:5 # Port "11111" should be listening on 192.168.2.2 with udp6
+rspec ./spec/srv.example.com/port_spec.rb:6 # Port "11111" should be listening with udp6
+
+/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -I/Library/Ruby/Gems/2.0.0/gems/rspec-support-3.5.0/lib:/Library/Ruby/Gems/2.0.0/gems/rspec-core-3.5.0/lib /Library/Ruby/Gems/2.0.0/gems/rspec-core-3.5.0/exe/rspec --pattern spec/srv.example.com/\*_spec.rb failed
+#

--- a/test-parameter-issue-explanation/port_spec.rb
+++ b/test-parameter-issue-explanation/port_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe port(11111) do
+
+  # the test case below will execute:
+  #   sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*:11111\\\
+  it { should be_listening.with('udp6') }
+  
+  it { should be_listening.on('192.168.2.2').with('udp6') }
+
+  # the same test case below will execute:
+  #   sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ \\\^udp6\\\ .\\\*\\\ 192.168.2.2:11111\\\
+  it { should be_listening.with('udp6') }
+
+end


### PR DESCRIPTION
_(ohhh... sorry for including the same twice, I decided to change wording: "bug" to "issue", but it all went into one PR, my bad)_

Per your suggestion to "send a pull request and attach test code to reproduce the bug", this is an explanation of the issue I encountered with Serverspec/Specinfra which looks to me like a a general flaw, not related to `port` test. I think it needs your attention.

The `port_spec.rb` should be self-explanatory, but basically it seems the parameters of a test case are not cleared between the individual test runs (`port_spec.log` contains the results, I intended tests to fail to show the actual commands).

This in effect causes a more general test case to implicitly inherit parameters if a more detailed one precedes a more general one.

In the example I included the same `it { should be_listening.with('udp6') }` runs two different commands depending on the position.