### PR TITLE
Provide :docker_container_exec_options similar to :docker_container_create_options

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -91,6 +91,7 @@ module Specinfra
       end
 
       def docker_run!(cmd, opts={})
+        opts.merge!(get_config(:docker_container_exec_options) || {})
         stdout, stderr, status = @container.exec(['/bin/sh', '-c', cmd], opts)
 
         CommandResult.new :stdout => stdout.join, :stderr => stderr.join,

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -16,6 +16,7 @@ module Specinfra
         :disable_sudo,
         :sudo_options,
         :docker_container_create_options,
+        :docker_container_exec_options,
         :docker_image,
         :docker_url,
         :lxc,


### PR DESCRIPTION
This will enable people to configure the User that specific commands are run as.

For example, when running a set of common tests on a container, you may
also want to check that the yum caches have been properly cleared out, but
that the installed packages are all up to date.

Very simple serverspec example:

```
  before(:all) do
    set :docker_container_exec_options, { :user => 'root' }
  end
  describe command('id') do
    its(:stdout) { should contain 'uid=0' }
  end
  after(:all) do
    set :docker_container_exec_options, {}
  end
```