### PR TITLE
Replace netstat with ss for Debian jessie

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -162,6 +162,7 @@ require 'specinfra/command/debian/base/service'
 # Debian V8 (inherit Debian)
 require 'specinfra/command/debian/v8'
 require 'specinfra/command/debian/v8/service'
+require 'specinfra/command/debian/v8/port'
 
 # Raspbian (inherit Debian)
 require 'specinfra/command/raspbian'

--- a/lib/specinfra/command/debian/base/port.rb
+++ b/lib/specinfra/command/debian/base/port.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Debian::Base::Port < Specinfra::Command::Linux::Base::Port
+end

--- a/lib/specinfra/command/debian/v8/port.rb
+++ b/lib/specinfra/command/debian/v8/port.rb
@@ -1,0 +1,5 @@
+class Specinfra::Command::Debian::V8::Port < Specinfra::Command::Debian::Base::Port
+  class << self
+    include Specinfra::Command::Module::Ss
+  end
+end

--- a/spec/command/debian/port_spec.rb
+++ b/spec/command/debian/port_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'debian'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq 'netstat -tunl | grep -- :80\ ' }
+end
+

--- a/spec/command/debian8/port_spec.rb
+++ b/spec/command/debian8/port_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'debian', :release => '8'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq 'ss -tunl | grep -- :80\ ' }
+end


### PR DESCRIPTION
ref:#445, #453

I'm poor at english.

PR #453 would replace all debian version netstat. I believe it is a problem.
Consideration of the backward compatibility, only change to the debian jessie.
Please close this PR if my misunderstanding.

I think jessie default command is ss.
Dockerhub debian:jessie official  repository
https://github.com/tianon/docker-brew-debian/blob/8072332b0dadf2f2590292c5e545bf0f9c2320e6/jessie/build.manifest#L31

