### PR TITLE
Escape asterisk in grep so it's not interpreted as zero or more spaces

### DIFF
--- a/lib/specinfra/command/module/ss.rb
+++ b/lib/specinfra/command/module/ss.rb
@@ -16,7 +16,7 @@ module Specinfra
         #     https://github.com/serverspec/serverspec/blob/master/lib/serverspec/type/port.rb
         def inaddr_any_to_asterisk(local_address)
           if local_address == '0.0.0.0'
-            '*'
+            '\*'
           else
             local_address
           end

--- a/spec/command/module/ss_spec.rb
+++ b/spec/command/module/ss_spec.rb
@@ -12,11 +12,11 @@ describe Specinfra::Command::Module::Ss do
   it { expect(klass.check_is_listening('80', options={:protocol => 'udp'})).to eq 'ss -unl4 | grep -- :80\ ' }
   it { expect(klass.check_is_listening('80', options={:protocol => 'udp6'})).to eq 'ss -unl6 | grep -- :80\ ' }
 
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -- \ \*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -- \ \*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -- \ \\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -- \ \\\*:80\ ' }
 
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl | grep -- \ 1.2.3.4:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ 1.2.3.4:80\ ' }

--- a/spec/command/module/ss_spec.rb
+++ b/spec/command/module/ss_spec.rb
@@ -12,11 +12,11 @@ describe Specinfra::Command::Module::Ss do
   it { expect(klass.check_is_listening('80', options={:protocol => 'udp'})).to eq 'ss -unl4 | grep -- :80\ ' }
   it { expect(klass.check_is_listening('80', options={:protocol => 'udp6'})).to eq 'ss -unl6 | grep -- :80\ ' }
 
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -- \ \\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -- \ \\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \\\\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \\\\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -- \ \\\\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \\\\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -- \ \\\\\*:80\ ' }
 
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl | grep -- \ 1.2.3.4:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ 1.2.3.4:80\ ' }

--- a/spec/command/module/ss_spec.rb
+++ b/spec/command/module/ss_spec.rb
@@ -12,11 +12,11 @@ describe Specinfra::Command::Module::Ss do
   it { expect(klass.check_is_listening('80', options={:protocol => 'udp'})).to eq 'ss -unl4 | grep -- :80\ ' }
   it { expect(klass.check_is_listening('80', options={:protocol => 'udp6'})).to eq 'ss -unl6 | grep -- :80\ ' }
 
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \\\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \\\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -- \ \\\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \\\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -- \ \\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -- \ \\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -- \ \\*:80\ ' }
 
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl | grep -- \ 1.2.3.4:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ 1.2.3.4:80\ ' }


### PR DESCRIPTION
Without this change, "should_not be_listening.on('0.0.0.0')" using ss for a
given port (say, 53) uses the following grep:

```
  ss -tunl | grep -- \ *:53\
```

This matches zero ore more spaces, followed by :53, followed by a space,
including lines such as:

```
udp    UNCONN     0      0      127.0.0.1:53                    *:*
```

It should be (note the additional backslash):

```
  ss -tunl | grep -- \ \*:53\
```

This matches a space followed by an asterisk, followed by :53, followed by
space, which is correct as it only matches lines such as:

```
udp    UNCONN     0      0              *:53                    *:*
```