### PR TITLE
Use the healthcheck system to wait for the container to be ready

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -79,7 +79,9 @@ module Specinfra
 
         @container = ::Docker::Container.create(opts)
         @container.start
-        # Check the container status (docker 1.12), if it's there and "Starting" then wait and try again
+        while @container.json['State'].key?('Health') && @container.json['State']['Health']['Status'] == "starting" do
+          sleep 0.5
+        end
       end
 
       def cleanup_container

--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -79,6 +79,7 @@ module Specinfra
 
         @container = ::Docker::Container.create(opts)
         @container.start
+        # Check the container status (docker 1.12), if it's there and "Starting" then wait and try again
       end
 
       def cleanup_container


### PR DESCRIPTION
Opened as a WIP (Need to familiarise with the docker API for ruby).

The idea is to remove the need of work around #545 and rely on the provided [healthcheck system](https://docs.docker.com/engine/reference/builder/#/healthcheck) to ensure that a container has been started entirely before running the rspec tests.