### PR TITLE
🏠 Set homepage URL to the gemspec

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["gosukenator@gmail.com"]
   spec.description   = %q{Common layer for serverspec and itamae}
   spec.summary       = %q{Common layer for serverspec and itamae}
-  spec.homepage      = ""
+  spec.homepage      = 'https://github.com/mizzy/specinfra'
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
This attribute could be used from some external tools, scripts, or services (in my case, an rbenv plugin named [gem-src](https://github.com/amatsuda/gem-src)).