### PR TITLE
Change Arista EOS family to just 'eos'

### DIFF
--- a/lib/specinfra/helper/detect_os/eos.rb
+++ b/lib/specinfra/helper/detect_os/eos.rb
@@ -6,7 +6,7 @@ class Specinfra::Helper::DetectOs::Eos < Specinfra::Helper::DetectOs
       if line =~ /EOS (\d[\d.]*[A-Z]*)/
         release = $1
       end
-      { :family => 'arista_eos', :release => release }
+      { :family => 'eos', :release => release }
     end
   end
 end

--- a/spec/helper/detect_os/eos_spec.rb
+++ b/spec/helper/detect_os/eos_spec.rb
@@ -11,7 +11,7 @@ describe Specinfra::Helper::DetectOs::Eos do
       CommandResult.new(:stdout => 'Arista Networks EOS 4.15.3F', :exit_status => 0)
     }
     expect(eos.detect).to include(
-      :family  => 'arista_eos',
+      :family  => 'eos',
       :release => '4.15.3F'
     )
   end
@@ -24,7 +24,7 @@ describe Specinfra::Helper::DetectOs::Eos do
       CommandResult.new(:stdout => 'Arista Networks EOS foo', :exit_status => 0)
     }
     expect(eos.detect).to include(
-      :family  => 'arista_eos',
+      :family  => 'eos',
       :release => nil
     )
   end


### PR DESCRIPTION
64d8587c13405b0ca0661e5214e98575e5744bd9 caused issues with some tests.  Backing off to just "eos" as the family.