### PR TITLE
fix appveyor fails

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "{build}"
+image: Previous Visual Studio 2015
 
-os: Windows Server 2012
 platform:
   - x64
 
@@ -40,6 +40,7 @@ install:
   - gem --version
   - appveyor DownloadFile -Url %bundler_url% -FileName bundler.gem
   - gem install --local bundler.gem --no-ri --no-rdoc ## appveyor often stops `gem install bundler`..?
+  - ps: $PSVersionTable
 
 build_script:
   - ruby -rfileutils -e 'FileUtils.rm_r(File.join(Gem.dir, "cache", "bundler")) if Dir.exists?(File.join(Gem.dir, "cache", "bundler"))'


### PR DESCRIPTION
using latest image !

- show PSVersionTable for debug
- use newer image
    - ref: http://help.appveyor.com/discussions/problems/5170-progresspreference-not-works-always-shown-preparing-modules-for-first-use-in-stderr
- remove os section
