### PR TITLE
support pkgng on freebsd 9

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -243,6 +243,10 @@ require 'specinfra/command/freebsd/base/user'
 require 'specinfra/command/freebsd/v6'
 require 'specinfra/command/freebsd/v6/user'
 
+# FreeBSD V9 (inherit FreeBSD)
+require 'specinfra/command/freebsd/v9'
+require 'specinfra/command/freebsd/v9/package'
+
 # FreeBSD V10 (inherit FreeBSD)
 require 'specinfra/command/freebsd/v10'
 require 'specinfra/command/freebsd/v10/package'

--- a/lib/specinfra/command/freebsd/v9.rb
+++ b/lib/specinfra/command/freebsd/v9.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Freebsd::V9 < Specinfra::Command::Freebsd::Base
+end

--- a/lib/specinfra/command/freebsd/v9/package.rb
+++ b/lib/specinfra/command/freebsd/v9/package.rb
@@ -1,0 +1,48 @@
+class Specinfra::Command::Freebsd::V9::Package < Specinfra::Command::Freebsd::Base::Package
+  class << self
+    def shell_check_pkgng
+      # This test works on FreeBSD >= 9.2. On 9.1, pkg has no -N option. Also,
+      # on fresh 9.1 installation there is only a placeholder pkg command,
+      # which immediatelly enters interactive mode and wants to install pkg
+      # package (so it's not suitable for a test like ours). On 9.0, there
+      # seems to be no pkg command/package at all.
+      "test `sysctl -n kern.osreldate` -ge 902000 && pkg -N > /dev/null 2>&1"
+    end
+
+    def shell_ifelse(cond, stmt_t, stmt_f)
+      "if #{cond}; then #{stmt_t}; else #{stmt_f}; fi"
+    end
+
+    def check_is_installed(package, version=nil)
+      if version
+        shell_ifelse(
+          shell_check_pkgng(),
+          "pkg query %v #{escape(package)} | grep -- #{escape(version)}",
+          "pkg_info -I #{escape(package)}-#{escape(version)}"
+        )
+      else
+        shell_ifelse(
+          shell_check_pkgng(),
+          "pkg info -e #{escape(package)}",
+          "pkg_info -Ix #{escape(package)}"
+        )
+      end
+    end
+
+    def install(package, version=nil, option='')
+      shell_ifelse(
+        shell_check_pkgng,
+        "pkg install -y #{option} #{package}",
+        "pkg_add -r #{option} install #{package}"
+      )
+    end
+
+    def get_version(package, opts=nil)
+      shell_ifelse(
+        shell_check_pkgng,
+        "pkg query %v #{escape(package)}",
+        "pkg_info -Ix #{escape(package)} | cut -f 1 -w | sed -n 's/^#{escape(package)}-//p'"
+      )
+    end
+  end
+end

--- a/spec/command/freebsd/package_spec.rb
+++ b/spec/command/freebsd/package_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+
+describe 'command/freebsd/package works correctly' do
+  before do
+    property[:os] = nil
+  end
+
+  context 'freebsd-base' do
+    before do
+      set :os, :family => 'freebsd'
+    end
+    describe 'get_command(:check_package_is_installed, "figlet")' do
+      it { expect(get_command(:check_package_is_installed, 'figlet')).to match /^pkg_info +-Ix +figlet$/ }
+    end
+    describe 'get_command(:check_package_is_installed, "figlet", "1.2.3")' do
+      it { expect(get_command(:check_package_is_installed, 'figlet', '1.2.3')).to match /^pkg_info +-I +figlet-1.2.3$/ }
+    end
+    describe 'get_command(:install_package, "figlet")' do
+      it { expect(get_command(:install_package, 'figlet')).to match /^pkg_add +-r +install +figlet$/ }
+    end
+  end
+
+  context 'freebsd-8' do
+    before do
+      set :os, :family => 'freebsd', :release => '8'
+    end
+    describe 'get_command(:check_package_is_installed, "figlet")' do
+      it { expect(get_command(:check_package_is_installed, 'figlet')).to match /^pkg_info +-Ix +figlet$/ }
+    end
+    describe 'get_command(:check_package_is_installed, "figlet", "1.2.3")' do
+      it { expect(get_command(:check_package_is_installed, 'figlet', '1.2.3')).to match /^pkg_info +-I +figlet-1.2.3$/ }
+    end
+    describe 'get_command(:install_package, "figlet")' do
+      it { expect(get_command(:install_package, 'figlet')).to match /^pkg_add +-r +install +figlet$/ }
+    end
+  end
+
+  context 'freebsd-9' do
+    before do
+      set :os, :family => 'freebsd', :release => '9'
+    end
+    let(:cond) do
+      /test +`sysctl +-n +kern.osreldate` +-ge +902000 *&& *pkg +-N *> *\/dev\/null +2>&1/
+    end
+    describe 'get_command(:check_package_is_installed, "figlet")' do
+      st = /pkg +info +-e +figlet/
+      sf = /pkg_info +-Ix +figlet/
+      it { expect(get_command(:check_package_is_installed, 'figlet')).
+           to match /^if +#{cond} *; *then +#{st} *; *else +#{sf} *; *fi$/ }
+    end
+    describe 'get_command(:check_package_is_installed, "figlet", "1.2.3")' do
+      st = /pkg +query +%v +figlet *\| *grep -- 1.2.3/
+      sf = /pkg_info +-I +figlet-1.2.3/
+      it { expect(get_command(:check_package_is_installed, 'figlet', '1.2.3')).
+           to match /^if +#{cond} *; *then +#{st} *; *else +#{sf} *; *fi$/ }
+    end
+    describe 'get_command(:install_package, "figlet")' do
+      st = /pkg +install +-y +figlet/
+      sf = /pkg_add +-r +install +figlet/
+      it { expect(get_command(:install_package, 'figlet')).
+           to match /^if +#{cond} *; *then +#{st} *; *else +#{sf} *; *fi$/ }
+    end
+    describe 'get_command(:get_package_version, "figlet")' do
+      st = /pkg +query +%v +figlet/
+      sf = /pkg_info +-Ix +figlet *\| *cut +-f +1 +-w *\| *sed +-n +'s\/\^figlet-\/\/p'/
+      it { expect(get_command(:get_package_version, 'figlet')).
+           to match /if +#{cond} *; *then +#{st} *; *else +#{sf} *; *fi/ }
+    end
+  end
+
+  context 'freebsd-10' do
+    before do
+      set :os, :family => 'freebsd', :release => '10'
+    end
+    describe 'get_command(:check_package_is_installed, "figlet")' do
+      it { expect(get_command(:check_package_is_installed, 'figlet')).to match /^pkg +info +-e +figlet$/ }
+    end
+    describe 'get_command(:check_package_is_installed, "figlet", "1.2.3")' do
+      it { expect(get_command(:check_package_is_installed, 'figlet', '1.2.3')).to match /^pkg +query +%v +figlet *\| *grep -- 1.2.3$/ }
+    end
+    describe 'get_command(:install_package, "figlet")' do
+      it { expect(get_command(:install_package, 'figlet')).to match /^pkg +install +-y +figlet$/ }
+    end
+  end
+end


### PR DESCRIPTION
There are two "tool-stacks" for managing packages on FreeBSD:
- old one (pkg_add, pkg_info, etc..) - let call it "pkg" ,
- new one (pkg add, pkg info, etc..) - called "pkgng".

FreeBSD <= 9.0 provides only the old 'pkg' stack. FreeBSD >= 10.0 provides only the new 'pkgng' stack. FreeBSD > 9.0 uses either 'pkg' or 'pkgng', depending on how user configured its OS.

This patch makes specinfra to work with FreeBSD 9.3 in both situations - where the OS uses 'pkg'  or 'pkgng'. I used this patch successfully to implement acceptance tests for my puppet modules (e.g. [ptomulik-portsng](https://github.com/ptomulik/puppet-portsng), [specinfra_patch.rb](https://github.com/ptomulik/puppet-portsng/blob/master/spec/specinfra_patch.rb)).