### PR TITLE
fixed invocation of pkg_add (freebsd)

### DIFF
--- a/lib/specinfra/command/freebsd/v6/package.rb
+++ b/lib/specinfra/command/freebsd/v6/package.rb
@@ -9,7 +9,7 @@ class Specinfra::Command::Freebsd::V6::Package < Specinfra::Command::Base::Packa
     end
 
     def install(package, version=nil, option='')
-      "pkg_add -r #{option} install #{package}"
+      "pkg_add -r #{option} #{package}"
     end
 
     def get_version(package, opts=nil)

--- a/lib/specinfra/command/freebsd/v8/package.rb
+++ b/lib/specinfra/command/freebsd/v8/package.rb
@@ -38,7 +38,7 @@ class Specinfra::Command::Freebsd::V8::Package < Specinfra::Command::Freebsd::Ba
       shell_ifelse(
         shell_check_pkgng(),
         "pkg install -y #{option} #{package}",
-        "pkg_add -r #{option} install #{package}"
+        "pkg_add -r #{option} #{package}"
       )
     end
 

--- a/spec/command/freebsd/package_spec.rb
+++ b/spec/command/freebsd/package_spec.rb
@@ -32,7 +32,7 @@ describe 'command/freebsd/package works correctly' do
       it { expect(get_command(:check_package_is_installed, 'figlet', '1.2.3')).to match /^pkg_info +-I +figlet-1.2.3$/ }
     end
     describe 'get_command(:install_package, "figlet")' do
-      it { expect(get_command(:install_package, 'figlet')).to match /^pkg_add +-r +install +figlet$/ }
+      it { expect(get_command(:install_package, 'figlet')).to match /^pkg_add +-r +figlet$/ }
     end
   end
 
@@ -47,7 +47,7 @@ describe 'command/freebsd/package works correctly' do
       it { expect(get_command(:check_package_is_installed, 'figlet', '1.2.3')).to match /^pkg_info +-I +figlet-1.2.3$/ }
     end
     describe 'get_command(:install_package, "figlet")' do
-      it { expect(get_command(:install_package, 'figlet')).to match /^pkg_add +-r +install +figlet$/ }
+      it { expect(get_command(:install_package, 'figlet')).to match /^pkg_add +-r +figlet$/ }
     end
   end
 
@@ -72,7 +72,7 @@ describe 'command/freebsd/package works correctly' do
     end
     describe 'get_command(:install_package, "figlet")' do
       st = /pkg +install +-y +figlet/
-      sf = /pkg_add +-r +install +figlet/
+      sf = /pkg_add +-r +figlet/
       it { expect(get_command(:install_package, 'figlet')).
            to match /^if +#{cond} *; *then +#{st} *; *else +#{sf} *; *fi$/ }
     end
@@ -105,7 +105,7 @@ describe 'command/freebsd/package works correctly' do
     end
     describe 'get_command(:install_package, "figlet")' do
       st = /pkg +install +-y +figlet/
-      sf = /pkg_add +-r +install +figlet/
+      sf = /pkg_add +-r +figlet/
       it { expect(get_command(:install_package, 'figlet')).
            to match /^if +#{cond} *; *then +#{st} *; *else +#{sf} *; *fi$/ }
     end


### PR DESCRIPTION
I've just caught it. The [pkg_add(1)] (https://www.freebsd.org/cgi/man.cgi?query=pkg_add&apropos=0&sektion=1&manpath=FreeBSD+9.1-RELEASE&arch=default&format=html) has no sub-command called ``install`` (it has no sub-commands at all) so the previous code always tried to install a package called ``install``, which obviously was failing. This PR shall fix the issue.