### PR TITLE
Add -NoProfile to fix suppress "Preparing modules for first use." message

### DIFF
--- a/lib/specinfra/backend/cmd.rb
+++ b/lib/specinfra/backend/cmd.rb
@@ -18,7 +18,7 @@ module Specinfra
           psh.sub!(":", "")
           psh = psh.prepend("/cygdrive/")
         end
-        result = execute_script %Q{#{psh} -encodedCommand #{encode_script(script)}}
+        result = execute_script %Q{#{psh} -NoProfile -encodedCommand #{encode_script(script)}}
 
         if @example
           @example.metadata[:command] = script


### PR DESCRIPTION
Running serverspec tests in AppVeyor does not work at the moment. Every test shows a XML error with `Preparing modules for first use.`.

There is a discussion at http://help.appveyor.com/discussions/problems/5170-progresspreference-not-works-always-shown-preparing-modules-for-first-use-in-stderr how to fix this.

But the workaround with `image: Previous Visual Studio 2015` in the `appveyor.yml` also no longer works.

See also these pull requests 
- https://github.com/WinRb/winrm-fs/pull/19
- https://github.com/chef/train/pull/152

The PR's showed me what is missing. I've added the `-NoProfile` option to the powershell call and it now works in AppVeyor even with the default image.

I've tested the change with a small patch of the `cmd.rb` in this build https://ci.appveyor.com/project/StefanScherer/serverspec-on-appveyor/build/14
