### PR TITLE
Libvirt LXC: allow to check for container existence and status

### DIFF
--- a/lib/specinfra/command/linux/base/lxc_container.rb
+++ b/lib/specinfra/command/linux/base/lxc_container.rb
@@ -1,11 +1,17 @@
 class Specinfra::Command::Linux::Base::LxcContainer < Specinfra::Command::Base::LxcContainer
   class << self
     def check_exists(container)
-      "lxc-ls -1 | grep -w #{escape(container)}"
+      [
+       "lxc-ls -1 | grep -w #{escape(container)}",
+       "virsh -c lxc:/// list --all --name | grep -w '^#{escape(container)}$'"
+      ].join(' || ')
     end
 
     def check_is_running(container)
-      "lxc-info -n #{escape(container)} -s | grep -w RUNNING"
+      [
+       "lxc-info -n #{escape(container)} -s | grep -w RUNNING",
+       "virsh -c lxc:/// list --all --name --state-running | grep -w '^#{escape(container)}$'"
+      ].join(' || ')
     end
   end
 end


### PR DESCRIPTION
This is similar to LXC but libvirt-lxc containers are implemented
differently and need the libvirt tools to check existence and status.