### PR TITLE
fix port when :os is openbsd

### DIFF
--- a/lib/specinfra/command/openbsd/base/port.rb
+++ b/lib/specinfra/command/openbsd/base/port.rb
@@ -1,6 +1,13 @@
 class Specinfra::Command::Openbsd::Base::Port < Specinfra::Command::Base::Port
   class << self
     def check_is_listening(port, opts={})
+      protocol = opts[:protocol]
+      case protocol
+      when 'tcp'
+        return "netstat -nat -f inet | egrep '(tcp.*.#{port}.*LISTEN$)'"
+      when 'udp'
+        return "netstat -nat -f inet | egrep '(udp.*.#{port}.*$)'"
+      end
       "netstat -nat -f inet | egrep '((tcp|udp).*\.#{port}.*LISTEN$)'"
     end
   end

--- a/spec/command/openbsd/port_spec.rb
+++ b/spec/command/openbsd/port_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'openbsd'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq "netstat -nat -f inet | egrep '((tcp|udp).*.80.*LISTEN$)'" }
+end
+
+describe get_command(:check_port_is_listening, '22', :protocol => 'tcp') do
+  it { should eq "netstat -nat -f inet | egrep '(tcp.*.22.*LISTEN$)'" }
+end
+
+describe get_command(:check_port_is_listening, '514', :protocol => 'udp') do
+  it { should eq "netstat -nat -f inet | egrep '(udp.*.514.*$)'" }
+end


### PR DESCRIPTION
fixes the code below

```ruby
  describe port(514) do
    it { should be_listening.with('udp') }
  end 
```