### PR TITLE
Add runit-enabled check

### DIFF
--- a/lib/specinfra/command/module/service/runit.rb
+++ b/lib/specinfra/command/module/service/runit.rb
@@ -6,6 +6,10 @@ module Specinfra
           def check_is_running_under_runit(service)
             "sv status #{escape(service)} | grep -E '^run: '"
           end
+
+          def check_is_enabled_under_runit(service)
+            "test ! -f /etc/sv/#{escape(service)}/down"
+          end
         end
       end
     end


### PR DESCRIPTION
Without a runit-specific test, `be_enabled` seems to fail (i.e. get the wrong answer) when asked about a runit service unless that service is also enabled via SysV as a backup.

Depends on mizzy/serverspec#580