### PR TITLE
Support no_dereference option for link_to

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -178,6 +178,7 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
     def link_to(link, target, options = {})
       option = '-s'
       option << 'f' if options[:force]
+      option << 'n' if options[:no_dereference]
       "ln #{option} #{escape(target)} #{escape(link)}"
     end
 

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -70,6 +70,14 @@ describe get_command(:link_file_to, '/link', '/target', :force => true) do
   it { should eq 'ln -sf /target /link' }
 end
 
+describe get_command(:link_file_to, '/link', '/target', :no_dereference => true) do
+  it { should eq 'ln -sn /target /link' }
+end
+
+describe get_command(:link_file_to, '/link', '/target', :force => true, :no_dereference => true) do
+  it { should eq 'ln -sfn /target /link' }
+end
+
 describe get_command(:remove_file, '/tmp') do
   it { should eq 'rm -rf /tmp' }
 end


### PR DESCRIPTION
Hi maintainers,

I use specinfra via [Itamae](https://github.com/itamae-kitchen/itamae), and I need the `-n` (`--no-dereference`) option in the below case. So I implemented this. Could you check this?

**Case: Version management by symlink**

For example, I manage versions of google-cloud-sdk by using symlink. In the below case, I need to change the `current` symlink destination to upgrade `google-cloud-sdk-100.0.0-linux-x86_64` to `google-cloud-sdk-132.0.0-linux-x86_64`. However, now specinfra supports only `-f` option, so the new symlink is created under the `current` directory.

```
# ls -l /opt/google-cloud-sdk/
total 8
lrwxrwxrwx 1 root root   37 Oct 27 11:31 current -> google-cloud-sdk-100.0.0-linux-x86_64
drwxr-xr-x 7 root root 4096 Oct 27 11:31 google-cloud-sdk-100.0.0-linux-x86_64
drwxr-xr-x 7 root root 4096 Oct 24 15:27 google-cloud-sdk-132.0.0-linux-x86_64
```