### PR TITLE
Port to Winrm v2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: "{build}"
-image: Previous Visual Studio 2015
+os: Windows Server 2012
 
 platform:
   - x64

--- a/lib/specinfra/backend/winrm.rb
+++ b/lib/specinfra/backend/winrm.rb
@@ -11,18 +11,20 @@ module Specinfra
         script = create_script(cmd)
         winrm = get_config(:winrm)
 
-        result = winrm.powershell(script)
-        stdout, stderr = [:stdout, :stderr].map do |s|
-          result[:data].select {|item| item.key? s}.map {|item| item[s]}.join
-        end
-        result[:exitcode] = 1 if result[:exitcode] == 0 and !stderr.empty?
+        winrm.shell(:powershell) do |shell|
+          result = shell.run(script)
+          stdout = result.stdout.to_s
+          stderr = result.stderr.to_s
 
-        if @example
-          @example.metadata[:command] = script
-          @example.metadata[:stdout]  = stdout + stderr
-        end
+          result.exitcode = 1 if result.exitcode == 0 and !stderr.empty?
 
-        CommandResult.new :stdout => stdout, :stderr => stderr, :exit_status => result[:exitcode]
+          if @example
+            @example.metadata[:command] = script
+            @example.metadata[:stdout]  = stdout + stderr
+          end
+
+          CommandResult.new :stdout => stdout, :stderr => stderr, :exit_status => result.exitcode
+        end
       end
     end
   end

--- a/lib/specinfra/backend/winrm.rb
+++ b/lib/specinfra/backend/winrm.rb
@@ -11,20 +11,34 @@ module Specinfra
         script = create_script(cmd)
         winrm = get_config(:winrm)
 
-        winrm.shell(:powershell) do |shell|
-          result = shell.run(script)
-          stdout = result.stdout.to_s
-          stderr = result.stderr.to_s
+        stdout, stderr = ''
+        exitcode = 0
 
-          result.exitcode = 1 if result.exitcode == 0 and !stderr.empty?
-
-          if @example
-            @example.metadata[:command] = script
-            @example.metadata[:stdout]  = stdout + stderr
+        if Gem.loaded_specs['winrm'].version < Gem::Version.create('2.0')
+          # Use winrm V1 API
+          result = winrm.powershell(script)
+          stdout, stderr = [:stdout, :stderr].map do |s|
+            result[:data].select {|item| item.key? s}.map {|item| item[s]}.join
           end
-
-          CommandResult.new :stdout => stdout, :stderr => stderr, :exit_status => result.exitcode
+          exitcode = result[:exitcode]
+        else
+          # Use winrm V2 API
+          winrm.shell(:powershell) do |shell|
+            result = shell.run(script)
+            stdout = result.stdout.to_s
+            stderr = result.stderr.to_s
+            exitcode = result.exitcode
+          end
         end
+
+        exitcode = 1 if exitcode == 0 and !stderr.empty?
+
+        if @example
+          @example.metadata[:command] = script
+          @example.metadata[:stdout]  = stdout + stderr
+        end
+
+        CommandResult.new :stdout => stdout, :stderr => stderr, :exit_status => exitcode
       end
     end
   end


### PR DESCRIPTION
As per 
* https://github.com/WinRb/WinRM
* http://www.hurryupandwait.io/blog/released-winrm-gem-20-first-cross-platform-open-sourced-psrp-client-implementation

Along with https://github.com/serverspec/serverspec-integration-test/pull/16, this seems to fix the broken appveyor builds as well. (So I think this will fix the broken builds we still see with https://github.com/mizzy/specinfra/pull/584)

These are probably breaking changes for windows users of serverspec and might require some changes to the doc. (Since we need to use `WinRM::Connection` instead of `WinRM::WinRMWebService`)

I thought I would still open the PR and see...