### PR TITLE
Accommodate non-standard gem_binary.

### DIFF
--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Base::Package < Specinfra::Command::Base
   class << self
-    def check_is_installed_by_gem(name, version=nil)
-      gem_installed_command("gem", name, version)
+    def check_is_installed_by_gem(name, version=nil, gem_binary="gem")
+      gem_installed_command(gem_binary, name, version)
     end
 
     def check_is_installed_by_td_agent_gem(name, version=nil)


### PR DESCRIPTION
Would like to add ability for serverspec to test package install for embedded chef gem's, so need to allow non-standard gem_binary