### PR TITLE
Specify an absolute path to "getenforce"

### DIFF
--- a/lib/specinfra/command/linux/base/selinux.rb
+++ b/lib/specinfra/command/linux/base/selinux.rb
@@ -3,7 +3,7 @@ class Specinfra::Command::Linux::Base::Selinux < Specinfra::Command::Base::Selin
     def check_has_mode(mode, policy = nil)
       cmd =  ""
       cmd += "test ! -f /etc/selinux/config || (" if mode == "disabled"
-      cmd += "getenforce | grep -i -- #{escape(mode)}"
+      cmd += "/usr/sbin/getenforce | grep -i -- #{escape(mode)}"
       cmd += %Q{ && grep -iE -- '^\\s*SELINUX=#{escape(mode)}\\>' /etc/selinux/config}
       cmd += %Q{ && grep -iE -- '^\\s*SELINUXTYPE=#{escape(policy)}\\>' /etc/selinux/config} if policy != nil
       cmd += ")" if mode == "disabled"


### PR DESCRIPTION
Some CentOS configurations use a restrictive default shell path that
excludes "/usr/sbin". On these systems, calling "getenforce" fails
because its path is absent from the default path list. This commit
changes "selinux.rb" to call "getenforce" with an absolute path.

Change-Id: Iec9642dce075840b2c3a4eb448d914f537945369