### PR TITLE
Optional dependency facter for host_inventory

### DIFF
--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -15,6 +15,7 @@ module Specinfra
       block_device
       user
       group
+      facter
     }
 
     include Enumerable

--- a/lib/specinfra/host_inventory/facter.rb
+++ b/lib/specinfra/host_inventory/facter.rb
@@ -1,0 +1,16 @@
+module Specinfra
+  class HostInventory
+    class Facter < Base
+      def get
+        $LOAD_PATH.unshift('/opt/puppetlabs/puppet/lib/ruby/vendor_ruby')
+        begin
+          require 'facter'
+
+          Facter.to_hash
+        rescue LoadError, StandardError
+          nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds facter as an optional dependency for additional host_inventory information.

This currently is not working and my attempts at debugging it are failing. At the invocation of `Facter.to_hash` nothing (unsure if empty or nil) seems to be getting returned, and any code placed afterwards inside `facter.rb` is not being executed (noticed this during debugging). However, if I place this code directly inside a Serverspec test it works flawlessly, so I am at a loss here.