### PR TITLE
SELinux disabled mode should be testable without requiring a restart

### DIFF
--- a/lib/specinfra/command/linux/base/selinux.rb
+++ b/lib/specinfra/command/linux/base/selinux.rb
@@ -2,11 +2,11 @@ class Specinfra::Command::Linux::Base::Selinux < Specinfra::Command::Base::Selin
   class << self
     def check_has_mode(mode, policy = nil)
       cmd =  ""
-      cmd += "test ! -f /etc/selinux/config || (" if mode == "disabled"
-      cmd += "getenforce | grep -i -- #{escape(mode)}"
+      cmd += "test ! -f /etc/selinux/config || ( " if mode == "disabled"
+      cmd += "(getenforce | grep -i -- #{escape(mode)})"
+      cmd += " || (getenforce | grep -i -- #{escape('permissive')}) )" if mode == "disabled"
       cmd += %Q{ && grep -iE -- '^\\s*SELINUX=#{escape(mode)}\\>' /etc/selinux/config}
       cmd += %Q{ && grep -iE -- '^\\s*SELINUXTYPE=#{escape(policy)}\\>' /etc/selinux/config} if policy != nil
-      cmd += ")" if mode == "disabled"
       cmd
     end
   end

--- a/spec/command/linux/selinux_spec.rb
+++ b/spec/command/linux/selinux_spec.rb
@@ -4,24 +4,25 @@ property[:os] = nil
 set :os, :family => 'linux'
 
 describe get_command(:check_selinux_has_mode, 'disabled') do
-  it do 
-    should eq %Q{test ! -f /etc/selinux/config || (} +
-              %Q{getenforce | grep -i -- disabled} +
-              %Q{ && grep -iE -- '^\\s*SELINUX=disabled\\>' /etc/selinux/config)}
-  end 
+  it do
+    should eq %Q{test ! -f /etc/selinux/config || ( (} +
+              %Q{getenforce | grep -i -- disabled) ||} +
+              %Q{ (getenforce | grep -i -- permissive) )} +
+              %Q{ && grep -iE -- '^\\s*SELINUX=disabled\\>' /etc/selinux/config}
+  end
 end
 
 describe get_command(:check_selinux_has_mode, 'permissive', nil) do
-  it do 
-    should eq %Q{getenforce | grep -i -- permissive} +
+  it do
+    should eq %Q{(getenforce | grep -i -- permissive)} +
               %Q{ && grep -iE -- '^\\s*SELINUX=permissive\\>' /etc/selinux/config}
-  end 
+  end
 end
 
 describe get_command(:check_selinux_has_mode, 'enforcing', 'targeted') do
-  it do 
-    should eq %Q{getenforce | grep -i -- enforcing} +
+  it do
+    should eq %Q{(getenforce | grep -i -- enforcing)} +
               %Q{ && grep -iE -- '^\\s*SELINUX=enforcing\\>' /etc/selinux/config} +
               %Q{ && grep -iE -- '^\\s*SELINUXTYPE=targeted\\>' /etc/selinux/config}
-  end 
+  end
 end


### PR DESCRIPTION
At the moment, when you disable SELinux in a running environment you have two options; set the current mode to 'permissive' and disable selinux within the config file (eg. /etc/selinux/config) or disable selinux and reboot the server.

Latter approach creates a lot of unnecessary work, like restarting the server and waiting for it to come back, especially with tools like Ansible, Chef etc. So I think former approach works best in an automated environment; disable selinux from the config file and set its current mode to permissive then test it.

I've changed the shell commands to check for current mode to be permissive and the mode in config is disabled, **only if** we're testing for disabled selinux mode. It should return true when these conditions are met.

Let me know what you think. Thanks!