### PR TITLE
Add support for net-ssh 4.0

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-scp"
-  spec.add_runtime_dependency "net-ssh", ">= 2.7", "< 4.0"
+  spec.add_runtime_dependency "net-ssh", ">= 2.7", "< 5.0"
   spec.add_runtime_dependency "net-telnet"
   spec.add_runtime_dependency "sfl"
 


### PR DESCRIPTION
Net-ssh 4.0 is no longer beta/rc and includes support for ed25519 keys and other features.