### PR TITLE
bugfixed the group.rb for AIX

### DIFF
--- a/lib/specinfra/command/aix/base/group.rb
+++ b/lib/specinfra/command/aix/base/group.rb
@@ -1,8 +1,13 @@
 class Specinfra::Command::Aix::Base::Group < Specinfra::Command::Base::Group
   class << self
-    def check_has_gid(group, gid)
-      regexp = "^#{group}"
-      "cat etc/group | grep -w -- #{escape(regexp)} | cut -f 3 -d ':' | grep -w -- #{escape(gid)}"
+
+    def check_exists(group)
+      "lsgroup #{escape(group)}"
     end
+
+    def check_has_gid(group, gid)
+      "lsgroup -a id #{escape(group)} | cut -f 2 -d '=' | grep -w -- #{escape(gid)}"
+    end
+
   end
 end

--- a/lib/specinfra/version.rb
+++ b/lib/specinfra/version.rb
@@ -1,3 +1,3 @@
 module Specinfra
-  VERSION = "2.66.4"
+  VERSION = "2.66.5"
 end


### PR DESCRIPTION
For AIX we faced a bug during running specinfra.
When verifying the settings of a group in AIX, specinfra reports incorrectly failures.

I adjusted the group.rb in lib/specinfra/command/aix/base and added the correct command to check the existence of a group and adjusted the check on the primary group with the correct aix command.
