### PR TITLE
container regex on start

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -82,6 +82,28 @@ module Specinfra
         while @container.json['State'].key?('Health') && @container.json['State']['Health']['Status'] == "starting" do
           sleep 0.5
         end
+
+        if get_config(:docker_container_ready_regex) then
+
+          counter=0
+          timeout = get_config(:docker_container_start_timeout) or 30
+          while counter < timeout do
+            match = @container.logs({ :stdout => true }).split("\n").grep(get_config(:docker_container_ready_regex))
+            puts "Waiting for matching regex: #{get_config(:docker_container_ready_regex)}" if get_config(:docker_debug)
+            unless match.empty? then
+              puts "Container #{@container.id} is ready." if get_config(:docker_debug)
+              break
+            end
+            puts "Sleeping for 5 seconds while container starts up...#{counter}/#{timeout}" if get_config(:docker_debug)
+            sleep 5
+            counter += 5
+          end
+          if counter >= timeout then
+            @container.kill unless get_config(:docker_debug)
+            @container.delete(:force => true) unless get_config(:docker_debug)
+            fail "Container #{@container} did not start in time."
+          end
+        end
       end
 
       def cleanup_container


### PR DESCRIPTION
My use case for this is running rspec tests against a bunch of different docker images.
The problem I've had is where there are setup tasks in the docker container before it's actually "ready" for the tests to run.

For example, a mysql image would have to create the initial mysql db files.
We have found that a simple delay isn't enough as you can't really determine how long startup might take.

This PR implements a method of providing a regex to search container logs output for.

Continuing with the mysql example, here is how we use this to run the tests.

spec_tests.rb:

set :backend, :docker
@image = Docker::Image.get(ENV['IMAGE'])
set :docker_image, @image.id
#set :docker_debug, true
set :docker_container_start_timeout, 60
set :docker_container_ready_regex, /mysqld_safe Starting mysqld daemon with databases from \/var\/lib\/mysql/
RSpec.configure do |c|
...tests here
end