### PR TITLE
Escape package name in package install

### DIFF
--- a/lib/specinfra/command/debian/base/package.rb
+++ b/lib/specinfra/command/debian/base/package.rb
@@ -3,7 +3,7 @@ class Specinfra::Command::Debian::Base::Package < Specinfra::Command::Linux::Bas
     def check_is_installed(package, version=nil)
       escaped_package = escape(package)
       if version
-        cmd = "dpkg-query -f '${Status} ${Version}' -W #{escaped_package} | grep -E '^(install|hold) ok installed #{escape(version)}$'"
+        cmd = "dpkg-query -f '${Status} ${Version}' -W #{escaped_package} | grep -E '^(install|hold) ok installed #{Regexp.escape(escape(version))}$'"
       else
         cmd = "dpkg-query -f '${Status}' -W #{escaped_package} | grep -E '^(install|hold) ok installed$'"
       end
@@ -18,7 +18,7 @@ class Specinfra::Command::Debian::Base::Package < Specinfra::Command::Linux::Bas
       else
         full_package = package
       end
-      "DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' #{option} install #{full_package}"
+      "DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' #{option} install #{escape(full_package)}"
     end
 
     def get_version(package, opts=nil)

--- a/lib/specinfra/command/redhat/base/package.rb
+++ b/lib/specinfra/command/redhat/base/package.rb
@@ -3,7 +3,8 @@ class Specinfra::Command::Redhat::Base::Package < Specinfra::Command::Linux::Bas
     def check_is_installed(package, version=nil)
       cmd = "rpm -q #{escape(package)}"
       if version
-        cmd = "#{cmd} | grep -w -- #{escape(package)}-#{escape(version)}"
+        full_package = "#{package}-#{version}"
+        cmd = "#{cmd} | grep -w -- #{Regexp.escape(escape(full_package))}"
       end
       cmd
     end
@@ -20,7 +21,7 @@ class Specinfra::Command::Redhat::Base::Package < Specinfra::Command::Linux::Bas
       else
         full_package = package
       end
-      cmd = "yum -y #{option} install #{full_package}"
+      cmd = "yum -y #{option} install #{escape(full_package)}"
     end
 
     def remove(package, option='')

--- a/spec/command/debian/package_spec.rb
+++ b/spec/command/debian/package_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'debian'
+
+describe get_command(:check_package_is_installed, 'telnet') do
+  it { should eq "dpkg-query -f '${Status}' -W telnet | grep -E '^(install|hold) ok installed$'" }
+end
+
+describe get_command(:check_package_is_installed, 'telnet', '0.17-36build2') do
+  it { should eq "dpkg-query -f '${Status} ${Version}' -W telnet | grep -E '^(install|hold) ok installed 0\\.17\\-36build2$'" }
+end
+
+describe get_command(:check_package_is_installed, 'linux-headers-$(uname -r)') do
+  it 'should be escaped (that is, command substitution should not work)' do
+    should eq "dpkg-query -f '${Status}' -W linux-headers-\\$\\(uname\\ -r\\) | grep -E '^(install|hold) ok installed$'"
+  end
+end
+
+describe get_command(:install_package, 'telnet') do
+  it { should eq "DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'  install telnet" }
+end
+
+describe get_command(:install_package, 'telnet', '0.17-36build2') do
+  it { should eq "DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'  install telnet\\=0.17-36build2" }
+end
+
+describe get_command(:install_package, 'linux-headers-$(uname -r)') do
+  it 'should be escaped (that is, command substitution should not work)' do
+    should eq "DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'  install linux-headers-\\$\\(uname\\ -r\\)"
+  end
+end

--- a/spec/command/redhat/package_spec.rb
+++ b/spec/command/redhat/package_spec.rb
@@ -3,6 +3,30 @@ require 'spec_helper'
 property[:os] = nil
 set :os, { :family => 'redhat' }
 
-describe  get_command(:check_package_is_installed, 'httpd') do
-  it { should eq 'rpm -q httpd' }
+describe  get_command(:check_package_is_installed, 'telnet') do
+  it { should eq 'rpm -q telnet' }
+end
+
+describe  get_command(:check_package_is_installed, 'telnet', '0.17-48.el6.x86_64') do
+  it { should eq 'rpm -q telnet | grep -w -- telnet\\-0\\.17\\-48\\.el6\\.x86_64' }
+end
+
+describe  get_command(:check_package_is_installed, 'linux-headers-$(uname -r)') do
+  it 'should be escaped (that is, command substitution should not work' do
+    should eq 'rpm -q linux-headers-\\$\\(uname\\ -r\\)'
+  end
+end
+
+describe get_command(:install_package, 'telnet') do
+  it { should eq "yum -y  install telnet" }
+end
+
+describe get_command(:install_package, 'telnet', '0.17-48.el6.x86_64') do
+  it { should eq "yum -y  install telnet-0.17-48.el6.x86_64" }
+end
+
+describe get_command(:install_package, 'linux-headers-$(uname -r)') do
+  it 'should be escaped (that is, command substitution should no work)' do
+    should eq "yum -y  install linux-headers-\\$\\(uname\\ -r\\)"
+  end
 end


### PR DESCRIPTION
Fix https://github.com/itamae-kitchen/itamae/issues/238

Also, I found that the version string should be regexp escaped to be used in grep -E in `#check_is_install`. Fixed it together.