### PR TITLE
Rely on the build command and pre-command provided by Exec

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -27,7 +27,7 @@ module Specinfra
 
       def run_command(cmd, opts={})
         cmd = build_command(cmd)
-        cmd = add_pre_command(cmd)
+        run_pre_command(opts)
         docker_run!(cmd, opts)
       end
 
@@ -105,6 +105,13 @@ module Specinfra
           ::Docker::Image.get(name)
         rescue ::Docker::Error::NotFoundError
           ::Docker::Image.create('fromImage' => name)
+        end
+      end
+
+      def run_pre_command(opts)
+        if get_config(:pre_command)
+          cmd = build_command(get_config(:pre_command))
+          docker_run!(cmd, opts)
         end
       end
     end

--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -87,7 +87,7 @@ module Specinfra
 
       def docker_run!(cmd, opts={})
         opts.merge!(get_config(:docker_container_exec_options) || {})
-        stdout, stderr, status = @container.exec(cmd, opts)
+        stdout, stderr, status = @container.exec([cmd], opts)
 
         CommandResult.new :stdout => stdout.join, :stderr => stderr.join,
         :exit_status => status

--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -87,7 +87,7 @@ module Specinfra
 
       def docker_run!(cmd, opts={})
         opts.merge!(get_config(:docker_container_exec_options) || {})
-        stdout, stderr, status = @container.exec([cmd], opts)
+        stdout, stderr, status = @container.exec(cmd.shellsplit, opts)
 
         CommandResult.new :stdout => stdout.join, :stderr => stderr.join,
         :exit_status => status

--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -31,14 +31,6 @@ module Specinfra
         docker_run!(cmd, opts)
       end
 
-      def build_command(cmd)
-        cmd
-      end
-
-      def add_pre_command(cmd)
-        cmd
-      end
-
       def send_file(from, to)
         if @base_image
           @images << commit_container if @container
@@ -95,7 +87,7 @@ module Specinfra
 
       def docker_run!(cmd, opts={})
         opts.merge!(get_config(:docker_container_exec_options) || {})
-        stdout, stderr, status = @container.exec(['/bin/sh', '-c', cmd], opts)
+        stdout, stderr, status = @container.exec(cmd, opts)
 
         CommandResult.new :stdout => stdout.join, :stderr => stderr.join,
         :exit_status => status


### PR DESCRIPTION
This should give access to options such as `:shell`, `:precommand`, etc. to the docker backend.

I had to give multiple goes at it.
The idea is `build_command` works fine already, no need to recreate it. There is no need to force `/bin/sh` as the shell either. The command `shellsplit` will take the command we have and execute it as expected.

Regarding the pre_command, we unfortunately can't simply do `&&` in docker (because docker runs executables, not shell, the command itself will start the shell); so instead we do two docker_run, one with the pre_command, one with the actual command.

This gives access to `:interactive_shell`, `:login_shell`, `:shell` and `:precommand`.

I haven't played with `:path`, it might be worth having something that sets an env variable in docker, but still it makes docker testing much easier.