### PR TITLE
Fix double escape in dpkg version check.

### DIFF
--- a/lib/specinfra/command/debian/base/package.rb
+++ b/lib/specinfra/command/debian/base/package.rb
@@ -3,7 +3,7 @@ class Specinfra::Command::Debian::Base::Package < Specinfra::Command::Linux::Bas
     def check_is_installed(package, version=nil)
       escaped_package = escape(package)
       if version
-        cmd = "dpkg-query -f '${Status} ${Version}' -W #{escaped_package} | grep -E '^(install|hold) ok installed #{Regexp.escape(escape(version))}$'"
+        cmd = "dpkg-query -f '${Status} ${Version}' -W #{escaped_package} | grep -E '^(install|hold) ok installed #{Regexp.escape(version)}$'"
       else
         cmd = "dpkg-query -f '${Status}' -W #{escaped_package} | grep -E '^(install|hold) ok installed$'"
       end
@@ -30,4 +30,3 @@ class Specinfra::Command::Debian::Base::Package < Specinfra::Command::Linux::Bas
     end
   end
 end
-


### PR DESCRIPTION
A previous commit 8f5ad028d563371b2b59bc1e1613ae6590330942 added an extra escape to the version check for the Debian family of operating systems which broke the version check. This commit fixes that part of the commit.

Note related SO question here: http://stackoverflow.com/questions/42417864/serverspec-doesnt-check-package-version-correctly

RSpec test intentional failure shows that characters are now only being escaped once with the code update.