### PR TITLE
Restructures the selinux lib class, to fix the case where /etc/selinux/config does not exist in disabled mode

### DIFF
--- a/lib/specinfra/command/linux/base/selinux.rb
+++ b/lib/specinfra/command/linux/base/selinux.rb
@@ -1,12 +1,31 @@
 class Specinfra::Command::Linux::Base::Selinux < Specinfra::Command::Base::Selinux
   class << self
     def check_has_mode(mode, policy = nil)
+
       cmd =  ""
-      cmd += "test ! -f /etc/selinux/config || ( " if mode == "disabled"
+
+      # If disabled, then the absence of /etc/selinux/config is sufficient
+      cmd += "test ! -f /etc/selinux/config || " if mode == "disabled"
+
+      # If disabled, wrap the rest of the test in parentheses
+      # i.e. only test this stuff if /etc/selinux/config exists
+      cmd += "( ( " if mode == "disabled"
+
+      # Does getenforce return the same value as we are checking for?
       cmd += "(getenforce | grep -i -- #{escape(mode)})"
+
+      # If disabled, then permissive is considered a pass
       cmd += " || (getenforce | grep -i -- #{escape('permissive')}) )" if mode == "disabled"
+
+      # Ensure that /etc/selinux/config contains the mode we specify
       cmd += %Q{ && grep -iE -- '^\\s*SELINUX=#{escape(mode)}\\>' /etc/selinux/config}
+
+      # If we have specified a policy, ensure that is included in /etc/selinux/config
       cmd += %Q{ && grep -iE -- '^\\s*SELINUXTYPE=#{escape(policy)}\\>' /etc/selinux/config} if policy != nil
+
+      # End parenthesis for tests when /etc/selinux/config exists
+      cmd += ")" if mode == "disabled"
+
       cmd
     end
   end

--- a/spec/command/linux/selinux_spec.rb
+++ b/spec/command/linux/selinux_spec.rb
@@ -5,10 +5,10 @@ set :os, :family => 'linux'
 
 describe get_command(:check_selinux_has_mode, 'disabled') do
   it do
-    should eq %Q{test ! -f /etc/selinux/config || ( (} +
+    should eq %Q{test ! -f /etc/selinux/config || ( ( (} +
               %Q{getenforce | grep -i -- disabled) ||} +
               %Q{ (getenforce | grep -i -- permissive) )} +
-              %Q{ && grep -iE -- '^\\s*SELINUX=disabled\\>' /etc/selinux/config}
+              %Q{ && grep -iE -- '^\\s*SELINUX=disabled\\>' /etc/selinux/config)}
   end
 end
 


### PR DESCRIPTION
This fixes a bug introduced in d9e5721f6afa72990d408474ede0bc21ef027ca5 where the test incorrectly fails if /etc/selinux/config does not exist, when selinux is disabled.

Currently, if mode is disabled, it generates the following:

```
test ! -f /etc/selinux/config || ( (getenforce | grep -i -- disabled) || (getenforce | grep -i -- permissive) ) && grep -iE -- '^\s*SELINUX=disabled>' /etc/selinux/config
```

Expanding this out, with parenthesis to make it clearer what's going on...

```
(
	test ! -f /etc/selinux/config
	# check if this file does not exist.
	# it does not, so continue to the next bit...
	||
	( (getenforce | grep -i -- disabled) || (getenforce | grep -i -- permissive) )
	# This is ignored, because the file does not exist.
)
&&
(
	grep -iE -- '^\s*SELINUX=disabled>' /etc/selinux/config
	# grep this file...
	# but if this file does not exist, then it will fail
)
```

Now, it will generate:

```
test ! -f /etc/selinux/config || ( ( (getenforce | grep -i -- disabled) || (getenforce | grep -i -- permissive) ) && grep -iE -- '^\s*SELINUX=disabled\>' /etc/selinux/config)
```

Expanded...

```
test ! -f /etc/selinux/config
||
(
	(
		(getenforce | grep -i -- disabled)
		||
		(getenforce | grep -i -- permissive)
	)
	&&
	grep -iE -- '^\s*SELINUX=disabled\>' /etc/selinux/config
)
```