### PR TITLE
Fix detect sles and opensuse versions.

### DIFF
--- a/lib/specinfra/helper/detect_os/suse.rb
+++ b/lib/specinfra/helper/detect_os/suse.rb
@@ -1,13 +1,14 @@
 class Specinfra::Helper::DetectOs::Suse < Specinfra::Helper::DetectOs
   def detect
-    if run_command('ls /etc/SuSE-release').success?
-      line = run_command('cat /etc/SuSE-release').stdout
-      if line =~ /SUSE Linux Enterprise Server (\d+)/
-        release = $1
-        family = 'sles'
-      elsif line =~ /openSUSE (\d+\.\d+|\d+)/
-        release = $1
+    if run_command('ls /etc/os-release').success?
+      line = run_command('cat /etc/os-release').stdout
+      if line =~ /NAME=\"OpenSUSE"/
         family = 'opensuse'
+      elsif line =~ /NAME=\"SLES"/
+        family = 'sles'
+      end
+      if line =~ /VERSION_ID=\"(\d+\.\d+|\d+)\"/
+        release = $1
       end
       { :family => family, :release => release }
     end

--- a/spec/helper/detect_os/suse_spec.rb
+++ b/spec/helper/detect_os/suse_spec.rb
@@ -3,9 +3,18 @@ require 'specinfra/helper/detect_os/suse'
 
 describe Specinfra::Helper::DetectOs::Suse do
   suse = Specinfra::Helper::DetectOs::Suse.new(:exec)
-  it 'Should return opensuse 13 when openSUSE 13.2 is installed.' do
+  it 'Should return opensuse 42 when openSUSE 42.2 is installed.' do
     allow(suse).to receive(:run_command) {
-        CommandResult.new(:stdout => 'openSUSE 13.2 (x86_64)', :exit_status => 0)
+        CommandResult.new(:stdout => 'NAME=\"openSUSE Leap\"\nVERSION=\"42.2\"\nID=opensuse\nID_LIKE=\"suse\"\nVERSION_ID=\"42.2\"\nPRETTY_NAME=\"openSUSE Leap 42.2\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:opensuse:leap:42.2\"\nBUG_REPORT_URL=\"https://bugs.opensuse.org\"\nHOME_URL=\"https://www.opensuse.org/\"\n', :exit_status => 0)
+    }
+    expect(suse.detect).to include(
+      :family  => 'opensuse',
+      :release => '42.2'
+    )
+  end
+  it 'Should return opensuse 13.2 when openSUSE 13.2 is installed.' do
+    allow(suse).to receive(:run_command) {
+        CommandResult.new(:stdout => 'NAME=openSUSE\nVERSION=\"13.2 (Harlequin)\"\nVERSION_ID=\"13.2\"\nPRETTY_NAME=\"openSUSE 13.2 (Harlequin) (x86_64)\"\nID=opensuse\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:opensuse:opensuse:13.2\"\nBUG_REPORT_URL=\"https://bugs.opensuse.org\"\nHOME_URL=\"https://opensuse.org/\"\nID_LIKE=\"suse\"\n', :exit_status => 0)
     }
     expect(suse.detect).to include(
       :family  => 'opensuse',
@@ -14,7 +23,7 @@ describe Specinfra::Helper::DetectOs::Suse do
   end
   it 'Should return sles 12 when SUSE Linux Enterprise Server 12 is installed.' do
     allow(suse).to receive(:run_command) {
-      CommandResult.new(:stdout => 'SUSE Linux Enterprise Server 12', :exit_status => 0)
+      CommandResult.new(:stdout => 'NAME=\"SLES\"\nVERSION=\"12\"\nVERSION_ID=\"12\"\nPRETTY_NAME=\"SUSE Linux Enterprise Server 12\"\nID=\"sles\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:suse:sles:12\"\n', :exit_status => 0)
     }
     expect(suse.detect).to include(
       :family  => 'sles',


### PR DESCRIPTION
Before this change specinfra treats opensue 42.2 and 42.1
as the same systems but they don't.

File /etc/SuSE-release has been changed to /etc/os-release
because that file contains OS's minor and major version.