### PR TITLE
Fix opensuse/sles detect_os, fix debian ut and enable tests for detect_os

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ if defined?(RSpec)
   task :default => 'spec:all'
 
   namespace :spec do
-    task :all => [ :helper, :backend, :configuration, :processor, :command, :host_inventory ]
+    task :all => [ :helper, :backend, :configuration, :processor, :command, :host_inventory, :detect_os ]
 
     RSpec::Core::RakeTask.new(:helper) do |t|
       t.pattern = "spec/helper/*_spec.rb"
@@ -37,6 +37,7 @@ if defined?(RSpec)
       t.pattern = "spec/processor_spec.rb"
     end
 
+    desc 'Run tests for os detection mechanizm.'
     RSpec::Core::RakeTask.new(:detect_os) do |t|
       t.pattern = "spec/helper/detect_os/*_spec.rb"
     end

--- a/Rakefile
+++ b/Rakefile
@@ -37,6 +37,10 @@ if defined?(RSpec)
       t.pattern = "spec/processor_spec.rb"
     end
 
+    RSpec::Core::RakeTask.new(:detect_os) do |t|
+      t.pattern = "spec/helper/detect_os/*_spec.rb"
+    end
+
     RSpec::Core::RakeTask.new(:command) do |t|
       t.pattern = "spec/command/**/*.rb"
     end

--- a/lib/specinfra/helper/detect_os/debian.rb
+++ b/lib/specinfra/helper/detect_os/debian.rb
@@ -1,7 +1,7 @@
 class Specinfra::Helper::DetectOs::Debian < Specinfra::Helper::DetectOs
   def detect
     if (debian_version = run_command('cat /etc/debian_version')) && debian_version.success?
-      distro  = nil
+      distro  = 'debian'
       release = nil
       if (lsb_release = run_command("lsb_release -ir")) && lsb_release.success?
         lsb_release.stdout.each_line do |line|

--- a/lib/specinfra/helper/detect_os/suse.rb
+++ b/lib/specinfra/helper/detect_os/suse.rb
@@ -1,14 +1,14 @@
 class Specinfra::Helper::DetectOs::Suse < Specinfra::Helper::DetectOs
   def detect
-    if run_command('ls /etc/os-release').success? and run_command('ls /etc/SuSe-release').success?
+    if run_command('ls /etc/os-release').success? and run_command('zypper -V').success?
       line = run_command('cat /etc/os-release').stdout
-      if line =~ /NAME=\"OpenSUSE"/
+      if line =~ /ID=opensuse/
         family = 'opensuse'
       elsif line =~ /NAME=\"SLES"/
         family = 'sles'
-      elsif line =~ /openSUSE (\d+\.\d+|\d+)/
+      end
+      if line =~ /VERSION_ID=\"(\d+\.\d+|\d+)\"/
         release = $1
-        family = 'opensuse'
       end
       { :family => family, :release => release }
     end

--- a/spec/helper/detect_os/debian_spec.rb
+++ b/spec/helper/detect_os/debian_spec.rb
@@ -2,15 +2,66 @@ require 'spec_helper'
 require 'specinfra/helper/detect_os/debian'
 
 describe Specinfra::Helper::DetectOs::Debian do
-  darwin = Specinfra::Helper::DetectOs::Debian.new(Specinfra.backend)
+  debian = Specinfra::Helper::DetectOs::Debian.new(Specinfra.backend)
 
   it 'Should return debian 8.5 when jessie is installed.' do
     allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
       CommandResult.new(:stdout => "8.5\n", :exit_status => 0)
     }
-    expect(darwin.detect).to include(
+    allow(debian).to receive(:run_command).with('lsb_release -ir') {
+      CommandResult.new(:stdout => "8.5\n", :exit_status => 1)
+    }
+    allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
+      CommandResult.new(:stdout => "8.5\n", :exit_status => 1)
+    }
+    expect(debian.detect).to include(
       :family  => 'debian',
       :release => '8.5'
+    )
+  end
+  it 'Should return ubuntu 16.10 when yakkety is installed.' do
+    allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
+      CommandResult.new(:stdout => "stretch/sid", :exit_status => 0)
+    }
+    allow(debian).to receive(:run_command).with('lsb_release -ir') {
+      CommandResult.new(:stdout => "Distributor ID:Ubuntu\nRelease:16.10\n", :exit_status => 0)
+    }
+    allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
+      CommandResult.new(:stdout => "DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=16.10\nDISTRIB_CODENAME=yakkety\nDISTRIB_DESCRIPTION=\"Ubuntu 16.10\"", :exit_status => 0)
+    }
+    expect(debian.detect).to include(
+      :family  => 'ubuntu',
+      :release => '16.10'
+    )
+  end
+  it 'Should return ubuntu 16.04 when xenial is installed.' do
+    allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
+      CommandResult.new(:stdout => "stretch/sid", :exit_status => 0)
+    }
+    allow(debian).to receive(:run_command).with('lsb_release -ir') {
+      CommandResult.new(:stdout => "Distributor ID:Ubuntu\nRelease:16.04\n", :exit_status => 0)
+    }
+    allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
+      CommandResult.new(:stdout => "DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=16.04\nDISTRIB_CODENAME=xenial\nDISTRIB_DESCRIPTION=\"Ubuntu 16.04.2 LTS\"", :exit_status => 0)
+    }
+    expect(debian.detect).to include(
+      :family  => 'ubuntu',
+      :release => '16.04'
+    )
+  end
+  it 'Should return ubuntu 16.04 when xenial is installed in docker.' do
+    allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
+      CommandResult.new(:stdout => "stretch/sid", :exit_status => 0)
+    }
+    allow(debian).to receive(:run_command).with('lsb_release -ir') {
+      CommandResult.new(:stdout => 'lsb-release is not installed in docker image by default', :exit_status => 1)
+    }
+    allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
+      CommandResult.new(:stdout => "DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=16.04\nDISTRIB_CODENAME=xenial\nDISTRIB_DESCRIPTION=\"Ubuntu 16.04.2 LTS\"", :exit_status => 0)
+    }
+    expect(debian.detect).to include(
+      :family  => 'ubuntu',
+      :release => '16.04'
     )
   end
 end

--- a/spec/helper/detect_os/suse_spec.rb
+++ b/spec/helper/detect_os/suse_spec.rb
@@ -5,7 +5,7 @@ describe Specinfra::Helper::DetectOs::Suse do
   suse = Specinfra::Helper::DetectOs::Suse.new(:exec)
   it 'Should return opensuse 42 when openSUSE 42.2 is installed.' do
     allow(suse).to receive(:run_command) {
-        CommandResult.new(:stdout => 'NAME=\"openSUSE Leap\"\nVERSION=\"42.2\"\nID=opensuse\nID_LIKE=\"suse\"\nVERSION_ID=\"42.2\"\nPRETTY_NAME=\"openSUSE Leap 42.2\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:opensuse:leap:42.2\"\nBUG_REPORT_URL=\"https://bugs.opensuse.org\"\nHOME_URL=\"https://www.opensuse.org/\"\n', :exit_status => 0)
+        CommandResult.new(:stdout => "NAME=\"openSUSE Leap\"\nVERSION=\"42.2\"\nID=opensuse\nID_LIKE=\"suse\"\nVERSION_ID=\"42.2\"\nPRETTY_NAME=\"openSUSE Leap 42.2\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:opensuse:leap:42.2\"\nBUG_REPORT_URL=\"https://bugs.opensuse.org\"\nHOME_URL=\"https://www.opensuse.org/\"\n", :exit_status => 0)
     }
     expect(suse.detect).to include(
       :family  => 'opensuse',
@@ -14,7 +14,7 @@ describe Specinfra::Helper::DetectOs::Suse do
   end
   it 'Should return opensuse 13.2 when openSUSE 13.2 is installed.' do
     allow(suse).to receive(:run_command) {
-        CommandResult.new(:stdout => 'NAME=openSUSE\nVERSION=\"13.2 (Harlequin)\"\nVERSION_ID=\"13.2\"\nPRETTY_NAME=\"openSUSE 13.2 (Harlequin) (x86_64)\"\nID=opensuse\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:opensuse:opensuse:13.2\"\nBUG_REPORT_URL=\"https://bugs.opensuse.org\"\nHOME_URL=\"https://opensuse.org/\"\nID_LIKE=\"suse\"\n', :exit_status => 0)
+        CommandResult.new(:stdout => "NAME=openSUSE\nVERSION=\"13.2 (Harlequin)\"\nVERSION_ID=\"13.2\"\nPRETTY_NAME=\"openSUSE 13.2 (Harlequin) (x86_64)\"\nID=opensuse\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:opensuse:opensuse:13.2\"\nBUG_REPORT_URL=\"https://bugs.opensuse.org\"\nHOME_URL=\"https://opensuse.org/\"\nID_LIKE=\"suse\"\n", :exit_status => 0)
     }
     expect(suse.detect).to include(
       :family  => 'opensuse',
@@ -23,7 +23,7 @@ describe Specinfra::Helper::DetectOs::Suse do
   end
   it 'Should return sles 12 when SUSE Linux Enterprise Server 12 is installed.' do
     allow(suse).to receive(:run_command) {
-      CommandResult.new(:stdout => 'NAME=\"SLES\"\nVERSION=\"12\"\nVERSION_ID=\"12\"\nPRETTY_NAME=\"SUSE Linux Enterprise Server 12\"\nID=\"sles\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:suse:sles:12\"\n', :exit_status => 0)
+      CommandResult.new(:stdout => "NAME=\"SLES\"\nVERSION=\"12\"\nVERSION_ID=\"12\"\nPRETTY_NAME=\"SUSE Linux Enterprise Server 12\"\nID=\"sles\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:suse:sles:12\"\n", :exit_status => 0)
     }
     expect(suse.detect).to include(
       :family  => 'sles',


### PR DESCRIPTION
Summary:
1. Tests for detect_os helpers have been enabled.
2. Fix for opensuse and sles os detect mechanizm (I removed cat /etc/SuSE-release because it is decrecated and will be removed in future versions, zypper exists always.).
3. Fix debian detect_os tests and add tests for Ubuntu 16.10 and 16.04 (with and without lsb_release command installed.)