### PR TITLE
Fix host_inventory[virtualization][:system] return empty value when is a a docker container

### DIFF
--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -4,7 +4,7 @@ module Specinfra
       def get
         res = {}
         ## docker
-        if backend.run_command('grep -E "docker(/|-[0-9a-f]+)" /proc/1/cgroup').success?
+        if backend.run_command('grep -Eq "docker(/|-[0-9a-f]+)" /proc/1/cgroup').success?
           res[:system] = 'docker'
           return res
         end

--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -3,13 +3,13 @@ module Specinfra
     class Virtualization < Base
       def get
         res = {}
-        ## docker 
-        if backend.run_command('ls /.dockerinit').success?
+        ## docker
+        if backend.run_command('grep -E "docker(/|-[0-9a-f]+)" /proc/1/cgroup').success?
           res[:system] = 'docker'
           return res
         end
 
-        ## OpenVZ on Linux 
+        ## OpenVZ on Linux
         if backend.run_command('test -d /proc/vz -a ! -d /proc/bc').success?
           res[:system] = 'openvz'
           return res
@@ -18,7 +18,7 @@ module Specinfra
         cmd = backend.command.get(:get_inventory_system_product_name)
         ret = backend.run_command(cmd)
         if ret.exit_status == 0
-           res[:system] = parse_system_product_name(ret.stdout)   
+           res[:system] = parse_system_product_name(ret.stdout)
            return res
         end
 
@@ -27,8 +27,8 @@ module Specinfra
           res[:system] = parse_systemd_detect_virt_output(ret.stdout)
         end
 
-        res 
-      end 
+        res
+      end
 
       def parse_system_product_name(ret)
         product_name = case ret

--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -4,7 +4,7 @@ module Specinfra
       def get
         res = {}
         ## docker
-        if backend.run_command('grep -Eq "docker(/|-[0-9a-f]+)" /proc/1/cgroup||test -e /.dockerinit').success?
+        if backend.run_command('grep -Eqa \'docker(/|-[0-9a-f]+)\' /proc/1/cgroup||test -e /.dockerinit').success?
           res[:system] = 'docker'
           return res
         end

--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -4,7 +4,7 @@ module Specinfra
       def get
         res = {}
         ## docker
-        if backend.run_command('grep -Eq "docker(/|-[0-9a-f]+)" /proc/1/cgroup').success?
+        if backend.run_command('grep -Eq "docker(/|-[0-9a-f]+)" /proc/1/cgroup||test -e /.dockerinit').success?
           res[:system] = 'docker'
           return res
         end

--- a/spec/host_inventory/linux/virtualization_spec.rb
+++ b/spec/host_inventory/linux/virtualization_spec.rb
@@ -8,7 +8,7 @@ describe Specinfra::HostInventory::Virtualization do
   virt = Specinfra::HostInventory::Virtualization.new(host_inventory)
   let(:host_inventory) { nil }
   it 'Docker Image should return :system => "docker"' do
-    allow(virt.backend).to receive(:run_command).with('grep -Eq "docker(/|-[0-9a-f]+)" /proc/1/cgroup||test -e /.dockerinit') do
+    allow(virt.backend).to receive(:run_command).with('grep -Eqa \'docker(/|-[0-9a-f]+)\' /proc/1/cgroup||test -e /.dockerinit') do
       CommandResult.new(:stdout => '', :exit_status => 0)
     end
     expect(virt.get).to include(:system => 'docker')
@@ -16,7 +16,7 @@ describe Specinfra::HostInventory::Virtualization do
 
   let(:host_inventory) { nil }
   it 'Debian Wheezy on OpenVZ should return :system => "openvz"' do
-    allow(virt.backend).to receive(:run_command).with('ls /.dockerinit') do
+    allow(virt.backend).to receive(:run_command).with('grep -Eqa \'docker(/|-[0-9a-f]+)\' /proc/1/cgroup||test -e /.dockerinit') do
       CommandResult.new(:stdout => '', :exit_status => 2)
     end
     allow(virt.backend).to receive(:run_command).with('test -d /proc/vz -a ! -d /proc/bc') do

--- a/spec/host_inventory/linux/virtualization_spec.rb
+++ b/spec/host_inventory/linux/virtualization_spec.rb
@@ -5,12 +5,12 @@ describe Specinfra::HostInventory::Virtualization do
     set :os, { :family => 'linux' }
   end
 
-  virt = Specinfra::HostInventory::Virtualization.new(host_inventory) 
+  virt = Specinfra::HostInventory::Virtualization.new(host_inventory)
   let(:host_inventory) { nil }
   it 'Docker Image should return :system => "docker"' do
-    allow(virt.backend).to receive(:run_command).with('ls /.dockerinit') do 
-      CommandResult.new(:stdout => '/.dockerinit', :exit_status => 0)
-    end  
+    allow(virt.backend).to receive(:run_command).with('grep -Eq "docker(/|-[0-9a-f]+)" /proc/1/cgroup' ) do
+      CommandResult.new(:stdout => '', :exit_status => 0)
+    end
     expect(virt.get).to include(:system => 'docker')
   end
 
@@ -18,10 +18,10 @@ describe Specinfra::HostInventory::Virtualization do
   it 'Debian Wheezy on OpenVZ should return :system => "openvz"' do
     allow(virt.backend).to receive(:run_command).with('ls /.dockerinit') do
       CommandResult.new(:stdout => '', :exit_status => 2)
-    end 
+    end
     allow(virt.backend).to receive(:run_command).with('test -d /proc/vz -a ! -d /proc/bc') do
       CommandResult.new(:stdout => '', :exit_status => 0)
-    end 
+    end
     expect(virt.get).to include(:system => 'openvz')
   end
 

--- a/spec/host_inventory/linux/virtualization_spec.rb
+++ b/spec/host_inventory/linux/virtualization_spec.rb
@@ -8,7 +8,7 @@ describe Specinfra::HostInventory::Virtualization do
   virt = Specinfra::HostInventory::Virtualization.new(host_inventory)
   let(:host_inventory) { nil }
   it 'Docker Image should return :system => "docker"' do
-    allow(virt.backend).to receive(:run_command).with('grep -Eq "docker(/|-[0-9a-f]+)" /proc/1/cgroup' ) do
+    allow(virt.backend).to receive(:run_command).with('grep -Eq "docker(/|-[0-9a-f]+)" /proc/1/cgroup||test -e /.dockerinit') do
       CommandResult.new(:stdout => '', :exit_status => 0)
     end
     expect(virt.get).to include(:system => 'docker')


### PR DESCRIPTION
From this commit => https://github.com/docker/docker/commit/3b5fac462d21ca164b3778647420016315289034, the file `/.dockerinit` only used by the old and deprecated LXC execution driver. They were hacks required by docker when using LXC to run the containers.

For more info https://docs.docker.com/engine/deprecated/