### PR TITLE
Allow programs to use stderr without overriding their exitcode

### DIFF
--- a/lib/specinfra/backend/winrm.rb
+++ b/lib/specinfra/backend/winrm.rb
@@ -31,8 +31,6 @@ module Specinfra
           end
         end
 
-        exitcode = 1 if exitcode == 0 and !stderr.empty?
-
         if @example
           @example.metadata[:command] = script
           @example.metadata[:stdout]  = stdout + stderr


### PR DESCRIPTION
I'm not sure why this bit of code is there, but it changes the expected behaviour of the tests.

If an application uses stderr (to print warnings and such), this will force it to have the exitcode 1 (even though the exit code was 0!

An example of such undesired behaviour (which took a fair bit of time to debug) is `java -version`.
The output of `java -version` is entirely on stderr, and the command exits successfully (code 0), but this line obfuscates the results making the application appear as failing.