### PR TITLE
Do not make the powershell pre_command a conditional

### DIFF
--- a/lib/specinfra/backend/powershell/script_helper.rb
+++ b/lib/specinfra/backend/powershell/script_helper.rb
@@ -8,7 +8,7 @@ module Specinfra
           path = get_config(:path)
           if path
             cmd.strip!
-            cmd = 
+            cmd =
 <<-EOF
 $env:path = "#{path};$env:path"
 #{cmd}
@@ -21,12 +21,10 @@ EOF
           path = get_config(:path)
           if get_config(:pre_command)
             cmd.strip!
-            cmd = 
+            cmd =
 <<-EOF
-if (#{get_config(:pre_command)})
-{
+#{get_config(:pre_command)}
 #{cmd}
-}
 EOF
             cmd = "$env:path = \"#{path};$env:path\"\n#{cmd}" if path
           end


### PR DESCRIPTION
For some historical reasons (mizzy/serverspec@4ac94006) `add_pre_command` adds the pre-command as a conditional.

This behaviour is different from the other `pre_command` systems in specinfra where the goal is to execute some code beforehand rather than applying conditions on whether or not the test is going to be executed.
This can not only lead to false positives (if the test doesn't get executed at all), but also forces the `pre_command` to return `$True`.

This changes the behaviour to follow the same pattern as the other precommands.