### PR TITLE
Add support for TCP checks in alpine

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -127,6 +127,7 @@ require 'specinfra/command/aix/base/user'
 # Alpine (inherit Linux)
 require 'specinfra/command/alpine'
 require 'specinfra/command/alpine/base'
+require 'specinfra/command/alpine/base/host'
 require 'specinfra/command/alpine/base/package'
 require 'specinfra/command/alpine/base/process'
 require 'specinfra/command/alpine/base/service'

--- a/lib/specinfra/command/alpine/base/host.rb
+++ b/lib/specinfra/command/alpine/base/host.rb
@@ -1,0 +1,11 @@
+class Specinfra::Command::Alpine::Base::Host < Specinfra::Command::Base::Host
+  class << self
+    def check_is_reachable(host, port, proto, timeout)
+      if port.nil?
+        "ping -w #{escape(timeout)} -c 2 -n #{escape(host)}"
+      else
+        "nc -w #{escape(timeout)} -vvvvz#{proto.downcase.start_with?('u') ? 'u' : ''} #{escape(host)} #{escape(port)}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
According to the documentation in alpine

```
BusyBox v1.24.2 (2017-01-18 14:13:46 GMT) multi-call binary.

Usage: nc [OPTIONS] HOST PORT  - connect
nc [OPTIONS] -l -p PORT [HOST] [PORT]  - listen

        -e PROG Run PROG after connect (must be last)
        -l      Listen mode, for inbound connects
        -lk     With -e, provides persistent server
        -p PORT Local port
        -s ADDR Local address
        -w SEC  Timeout for connects and final net reads
        -i SEC  Delay interval for lines sent
        -n      Don't do DNS resolution
        -u      UDP mode
        -v      Verbose
        -o FILE Hex dump traffic
        -z      Zero-I/O mode (scanning)
```

In the case where protocol is `TCP` (or `tcp`), there is no `-t` option that can be used. TCP is assumed as long as `-u` isn't specified.