### PR TITLE
Detect os name coreos correctly

### DIFF
--- a/lib/specinfra/helper/detect_os/coreos.rb
+++ b/lib/specinfra/helper/detect_os/coreos.rb
@@ -6,7 +6,7 @@ class Specinfra::Helper::DetectOs::Coreos < Specinfra::Helper::DetectOs
       lsb_release = run_command("cat /etc/lsb-release")
       if lsb_release.success?
         lsb_release.stdout.each_line do |line|
-          distro  = line.split('=').last.strip if line =~ /^DISTRIB_ID=/
+          distro  = 'coreos' if line.include? "CoreOS"
           release = line.split('=').last.strip if line =~ /^DISTRIB_RELEASE=/
         end
       end


### PR DESCRIPTION
I am running serverspec test against CoreOS.

Before it was working fine for us, but recently we have updated our CoreOS from 1068.6.0 to 1235.6.0, and started failing.
We are getting following error, and we have identified that, this issue is because of CoreOS has been changed `OS_NAME` in [set_lsb_release](https://github.com/coreos/scripts/pull/620) file from just "CoreOS" to "Container Linux by CoreOS" which leads to detect_os the OS in specinfra, lib/specinfra/helper/detect_os/coreos.rb 

--------
File "/etc/passwd" should be owned by "root" 0.00067s

uninitialized constant Containerlinuxbycoreos

```
29    common_class = Specinfra::Command
30    base_class   = common_class.const_get('Base')
>> 31    os_class     = family.nil? ? base_class : common_class.const_get(family.capitalize)
32
33    if family && version
34# Install the coderay gem to get syntax highlighting
```

--------

* CoreOS Old Version: 

```
core@ip-10-26-193-69 ~ $ cat /etc/lsb-release
DISTRIB_ID=CoreOS
DISTRIB_RELEASE=1068.6.0
DISTRIB_CODENAME="MoreOS"
DISTRIB_DESCRIPTION="CoreOS 1068.6.0 (MoreOS)"
```

* CoreOS New Version:

```
core@ip-10-26-193-80 ~ $ cat /etc/lsb-release
DISTRIB_ID="Container Linux by CoreOS"
DISTRIB_RELEASE=1235.6.0
DISTRIB_CODENAME="Ladybug"
DISTRIB_DESCRIPTION="Container Linux by CoreOS 1235.6.0 (Ladybug)" 
```
