### PR TITLE
Fix double escape in rpm version check.

### DIFF
--- a/lib/specinfra/command/redhat/base/package.rb
+++ b/lib/specinfra/command/redhat/base/package.rb
@@ -4,7 +4,7 @@ class Specinfra::Command::Redhat::Base::Package < Specinfra::Command::Linux::Bas
       cmd = "rpm -q #{escape(package)}"
       if version
         full_package = "#{package}-#{version}"
-        cmd = "#{cmd} | grep -w -- #{Regexp.escape(escape(full_package))}"
+        cmd = "#{cmd} | grep -w -- #{Regexp.escape(full_package)}"
       end
       cmd
     end
@@ -29,12 +29,3 @@ class Specinfra::Command::Redhat::Base::Package < Specinfra::Command::Linux::Bas
     end
   end
 end
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
A previous commit f003ecf added an extra escape to the version check for the RedHat family of operating systems which broke the version check. This commit fixes that part of the commit.

See also #608 for similar situation and lead up to PR.