### PR TITLE
fix routing table device column of FreeBSD

### DIFF
--- a/lib/specinfra/command/freebsd/base/routing_table.rb
+++ b/lib/specinfra/command/freebsd/base/routing_table.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Freebsd::Base::RoutingTable < Specinfra::Command::Base::RoutingTable
   class << self
     def check_has_entry(destination)
-      %Q{netstat -rnW | grep #{destination} | awk '{print $1, "via", $2, "dev", $7, " "}'}
+      %Q{netstat -rnW | grep #{destination} | awk '{print $1, "via", $2, "dev", $6, " "}'}
     end
 
     alias :get_entry :check_has_entry


### PR DESCRIPTION
I think it's a simple bug.