### PR TITLE
Add Debian 9

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -171,6 +171,11 @@ require 'specinfra/command/debian/v8'
 require 'specinfra/command/debian/v8/service'
 require 'specinfra/command/debian/v8/port'
 
+# Debian V9 (inherit Debian V8)
+require 'specinfra/command/debian/v9'
+require 'specinfra/command/debian/v9/service'
+require 'specinfra/command/debian/v9/port'
+
 # Raspbian (inherit Debian)
 require 'specinfra/command/raspbian'
 

--- a/lib/specinfra/command/debian/v9.rb
+++ b/lib/specinfra/command/debian/v9.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Debian::V9 < Specinfra::Command::Debian::V8
+end

--- a/lib/specinfra/command/debian/v9/port.rb
+++ b/lib/specinfra/command/debian/v9/port.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Debian::V9::Port < Specinfra::Command::Debian::V8::Port; end

--- a/lib/specinfra/command/debian/v9/service.rb
+++ b/lib/specinfra/command/debian/v9/service.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Debian::V9::Service < Specinfra::Command::Debian::V8::Service; end

--- a/spec/command/debian9/port_spec.rb
+++ b/spec/command/debian9/port_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'debian', :release => '9'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq 'ss -tunl | grep -- :80\ ' }
+end


### PR DESCRIPTION
I found this fork that has added the support for debian 9, which would help testing it specially now that its time to upgrade and be_listening in serverspec fails dues to the removal of net-tools in debian 9 default.

My mistake if anybody gets pissed for making this pull request.
