### PR TITLE
Allow to switch backends

### DIFF
--- a/lib/specinfra/helper/os.rb
+++ b/lib/specinfra/helper/os.rb
@@ -4,32 +4,8 @@ module Specinfra
   module Helper
     module Os
       def os
-        property[:os] = {} if ! property[:os]
-        if ! property[:os].include?(:family)
-          property[:os] = detect_os
-        end
-        property[:os]
-      end
-
-      private
-      def detect_os
-        return Specinfra.configuration.os if Specinfra.configuration.os
-
-        backend = Specinfra.configuration.backend
-        if backend == :cmd || backend == :winrm
-          return { :family => 'windows', :release => nil, :arch => nil }
-        end
-
-        Specinfra::Helper::DetectOs.subclasses.each do |c|
-          res = c.detect
-          if res
-            res[:arch] ||= Specinfra.backend.run_command('uname -m').stdout.strip
-            return res
-          end
-        end
-        raise NotImplementedError, "Specinfra failed os detection."
+        property[:os] = Specinfra.backend.os_info
       end
     end
   end
 end
-

--- a/lib/specinfra/helper/os.rb
+++ b/lib/specinfra/helper/os.rb
@@ -4,7 +4,9 @@ module Specinfra
   module Helper
     module Os
       def os
-        property[:os] = Specinfra.backend.os_info
+        property[:os] = Specinfra.configuration.os ?
+          Specinfra.configuration.os :
+          Specinfra.backend.os_info
       end
     end
   end

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -113,6 +113,7 @@ describe 'os' do
     # clear os information cache
     property[:os] = nil
     Specinfra.configuration.instance_variable_set(:@os, nil)
+    Specinfra.backend.instance_variable_set(:@os_info, nil)
   end
 
   context 'test ubuntu with lsb_release command' do
@@ -185,4 +186,3 @@ EOF
     end
   end
 end
-


### PR DESCRIPTION
Use correct `os` variable when backend is switched to another. 

It allows to use multiple backends with Serverspec:
```ruby
require "serverspec"
require "docker"

set :backend, :docker
set :docker_container, ENV["DOCKER_CONTAINER"]

describe "Docker image" do
  before(:each) { set :backend, :docker }

  describe docker_image(ENV["DOCKER_IMAGE"]) do
    before(:each) { set :backend, :exec }
    it { is_expected.to exist }
  end

  describe "Operating system" do
    context "family" do
      subject { os[:family] }
      it { is_expected.to eq(ENV["OS_FAMILY"]) }
    end
    context "release" do
      subject { os[:release] }
      it { is_expected.to eq(ENV["OS_VERSION"]) }
    end
  end

  describe package("bash") do
    it { is_expected.to be_installed }
  end
end
```