### PR TITLE
Updated suse.rb to detect OS info on SUSE 11 machine

### DIFF
--- a/lib/specinfra/helper/detect_os/suse.rb
+++ b/lib/specinfra/helper/detect_os/suse.rb
@@ -11,6 +11,16 @@ class Specinfra::Helper::DetectOs::Suse < Specinfra::Helper::DetectOs
         release = $1
       end
       { :family => family, :release => release }
+    elsif run_command('ls /etc/SuSE-release').success? and run_command('zypper -V').success?
+      line = run_command('cat /etc/SuSE-release').stdout
+      if line =~ /SUSE Linux Enterprise Server (\d+)/
+        release = $1
+        family = 'suse'
+      elsif line =~ /openSUSE (\d+\.\d+|\d+)/
+        release = $1
+        family = 'opensuse'
+      end
+      { :family => family, :release => release }
     end
   end
 end


### PR DESCRIPTION
Current logic in suse.rb helper file is fetching OS info from /etc/os-release file. 
But this os-release file is not present on SUSE 11 machine so we need to have the older logic as well, which will detect the OS info from /etc/SuSE-release file.