### PR TITLE
get_version returns malformed value if the package name contains a hyphen

### DIFF
--- a/lib/specinfra/command/alpine/base/package.rb
+++ b/lib/specinfra/command/alpine/base/package.rb
@@ -13,7 +13,7 @@ class Specinfra::Command::Alpine::Base::Package < Specinfra::Command::Linux::Bas
     end
 
     def get_version(package, _opts = nil)
-      "apk version #{package} | tail -n1 | awk '{ print $1; }' | cut -d- -f2-"
+      "apk version #{package} | tail -n1 | awk '{ print $3; }'"
     end
   end
 end


### PR DESCRIPTION
`apk version` returns this information:
```bash
> apk version -U ruby-io-console
Installed:                                Available:
ruby-io-console-2.4.1-r3                = 2.4.1-r3
```

The current implementation uses the first column from which removes the text up to the first hyphen. If the package name contains a hyphen, the part of the name becomes the part of the version:
```bash
> apk version -U ruby-io-console | tail -n1 | awk '{ print $1; }' | cut -d- -f2-
io-console-2.4.1-r3
```
It would be better to use the third column which contains the version:
```bash
> apk version -U ruby-io-console | tail -n1 | awk '{ print $3; }'
2.4.1-r3
```