### PR TITLE
Allow to test main package version on Alpine Linux

### DIFF
--- a/lib/specinfra/command/alpine/base/package.rb
+++ b/lib/specinfra/command/alpine/base/package.rb
@@ -1,8 +1,13 @@
 class Specinfra::Command::Alpine::Base::Package < Specinfra::Command::Linux::Base::Package
   class << self
     def check_is_installed(package, version = nil)
-      pkg = [escape(package), version].compact.join('=')
-      "apk info -qe #{pkg}"
+      if version.nil? then
+        pkg = escape(package)
+        "apk info -qe #{pkg}"
+      else
+        pkg = "#{package}-#{version}"
+        "apk info -v | grep -w -- '^#{Regexp.escape(pkg)}'"
+      end
     end
 
     alias_method :check_is_installed_by_apk, :check_is_installed


### PR DESCRIPTION
The current implementation only allows to test the full package version:
```ruby
describe package("ruby") do
  it { is_expected.to be_installed.with_version("2.4.1-r3") }
end
```

This change will also allows to test the main version of the package:
```ruby
describe package("ruby") do
  it { is_expected.to be_installed.with_version("2.4.1") }
end
```