### PR TITLE
Add CentOS family and fix CentOS 7 listening port check

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -97,6 +97,17 @@ require 'specinfra/command/redhat/v7/host'
 require 'specinfra/command/redhat/v7/service'
 require 'specinfra/command/redhat/v7/port'
 
+# CentOS (inherit RedHat)
+require 'specinfra/command/centos'
+require 'specinfra/command/centos/base'
+
+# CentOS V5 (inherit RedHat V5)
+require 'specinfra/command/centos/v5'
+
+# Centos V7 (inherit RedHat V7)
+require 'specinfra/command/centos/v7'
+require 'specinfra/command/centos/v7/port'
+
 # Fedora (inherit RedhHat)
 require 'specinfra/command/fedora'
 require 'specinfra/command/fedora/base'

--- a/lib/specinfra/command/centos.rb
+++ b/lib/specinfra/command/centos.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Centos;end

--- a/lib/specinfra/command/centos/base.rb
+++ b/lib/specinfra/command/centos/base.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Centos::Base < Specinfra::Command::Redhat::Base
+end

--- a/lib/specinfra/command/centos/v5.rb
+++ b/lib/specinfra/command/centos/v5.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Centos::V5 < Specinfra::Command::Redhat::V5
+end

--- a/lib/specinfra/command/centos/v7.rb
+++ b/lib/specinfra/command/centos/v7.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Centos::V7 < Specinfra::Command::Redhat::V7
+end

--- a/lib/specinfra/command/centos/v7/port.rb
+++ b/lib/specinfra/command/centos/v7/port.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Centos::V7::Port < Specinfra::Command::Linux::Base::Port
+end

--- a/lib/specinfra/helper/detect_os/redhat.rb
+++ b/lib/specinfra/helper/detect_os/redhat.rb
@@ -1,8 +1,16 @@
 class Specinfra::Helper::DetectOs::Redhat < Specinfra::Helper::DetectOs
   def detect
+    # CentOS also has an /etc/redhat-release so the CentOS check must
+    # come before the RedHat check
+    if run_command('ls /etc/centos-release').success?
+      line = run_command('cat /etc/centos-release').stdout
+      if line =~ /release (\d[\d.]*)/
+        release = $1
+      end
+      { :family => 'centos', :release => release }
     # Fedora also has an /etc/redhat-release so the Fedora check must
     # come before the RedHat check
-    if run_command('ls /etc/fedora-release').success?
+    elsif run_command('ls /etc/fedora-release').success?
       line = run_command('cat /etc/redhat-release').stdout
       if line =~ /release (\d[\d]*)/
         release = $1
@@ -13,7 +21,6 @@ class Specinfra::Helper::DetectOs::Redhat < Specinfra::Helper::DetectOs
       if line =~ /release (\d[\d.]*)/
         release = $1
       end
-
       { :family => 'redhat', :release => release }
     elsif run_command('ls /etc/system-release').success?
       line = run_command('cat /etc/system-release').stdout
@@ -24,8 +31,3 @@ class Specinfra::Helper::DetectOs::Redhat < Specinfra::Helper::DetectOs
     end
   end
 end
-
-
-
-
-

--- a/spec/command/centos7/port_spec.rb
+++ b/spec/command/centos7/port_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'centos', :release => '7'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq 'netstat -tunl | grep -- :80\ ' }
+end

--- a/spec/command/factory_spec.rb
+++ b/spec/command/factory_spec.rb
@@ -17,7 +17,6 @@ describe 'create_command_class work correctly' do
       set :os, :family => 'redhat'
     end
     it { expect(Specinfra.command.send(:create_command_class, 'file')).to eq Specinfra::Command::Redhat::Base::File }
-
     it { expect(Specinfra.command.send(:create_command_class, 'selinux')).to eq Specinfra::Command::Linux::Base::Selinux }
   end
 
@@ -26,5 +25,19 @@ describe 'create_command_class work correctly' do
       set :os, :family => 'redhat', :release => 7
     end
     it { expect(Specinfra.command.send(:create_command_class, 'file')).to eq Specinfra::Command::Redhat::V7::File }
+  end
+
+  context 'family: centos, release: nil' do
+    before do
+      set :os, :family => 'centos'
+    end
+    it { expect(Specinfra.command.send(:create_command_class, 'port')).to eq Specinfra::Command::Centos::Base::Port }
+  end
+
+  context 'family: centos, release: 7' do
+    before do
+      set :os, :family => 'centos', :release => 7
+    end
+    it { expect(Specinfra.command.send(:create_command_class, 'port')).to eq Specinfra::Command::Centos::V7::Port }
   end
 end


### PR DESCRIPTION
CentOS 7 does not have installed ss (at least centos:7 Docker image) so I
* add CentOS family awareness and detection
* fix CentOS 7 listening port check
* add tests for CentOS 7 listening port check