### PR TITLE
Fix ECMP route in routing_table

### DIFF
--- a/lib/specinfra/command/base/routing_table.rb
+++ b/lib/specinfra/command/base/routing_table.rb
@@ -1,7 +1,10 @@
 class Specinfra::Command::Base::RoutingTable < Specinfra::Command::Base
   class << self
     def check_has_entry(destination)
-      "ip route show #{destination} | grep #{destination}"
+      if destination == "default"
+        destination = "0.0.0.0/0"
+      end
+      "ip route show #{destination}"
     end
 
     alias :get_entry :check_has_entry

--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -175,7 +175,7 @@ module Specinfra
           :interface   => expected_attr[:interface] ? $3 : nil
         }
       else
-        matches = ret.stdout.scan(/^(\S+)(?: via (\S+))? dev (\S+).+\n|^(\S+).+\n|\s+nexthop via (\S+)\s+dev (\S+).+/)
+        matches = ret.stdout.scan(/^(\S+)(?: via (\S+))? dev (\S+).+\n|^(\S+).*\n|\s+nexthop via (\S+)\s+dev (\S+).+/)
         if matches.length > 1
           # ECMP route
           destination = nil
@@ -183,9 +183,9 @@ module Specinfra
             if groups[3]
               destination = groups[3]
               next
-            else
-              next unless expected_attr[:interface] == groups[5]
             end
+            next if expected_attr[:gateway] && expected_attr[:gateway] != groups[4]
+            next if expected_attr[:interface] && expected_attr[:interface] != groups[5]
 
             actual_attr = {
               :destination => destination,


### PR DESCRIPTION
Since "ip route show default" displays all the routes, "| grep #{destination}" is added in #288 .
However, with this change the results are incorrect in the case of multipath.

Therefore, when the destination is "default", only the default route is displayed by changing the destination to "0.0.0.0/0".

```
[vagrant@localhost ~]$  ip route show default
default via 10.0.2.2 dev enp0s3  proto static  metric 100
10.0.2.0/24 dev enp0s3  proto kernel  scope link  src 10.0.2.15  metric 100
10.100.0.1
	nexthop via 192.168.33.10  dev enp0s8 weight 1
	nexthop via 192.168.33.20  dev enp0s9 weight 1
192.168.33.0/24 dev enp0s9  proto kernel  scope link  src 192.168.33.20  metric 100
192.168.33.0/24 dev enp0s8  proto kernel  scope link  src 192.168.33.10  metric 101
```
```
[vagrant@localhost ~]$ ip route show 0.0.0.0/0
default via 10.0.2.2 dev enp0s3  proto static  metric 100
```

Also fixed some bugs for multipath case.