### PR TITLE
Fix process checkers

### DIFF
--- a/lib/specinfra/command/base/process.rb
+++ b/lib/specinfra/command/base/process.rb
@@ -1,19 +1,19 @@
 class Specinfra::Command::Base::Process < Specinfra::Command::Base
   class << self
     def get(process, opts)
-      "ps -C #{escape(process)} -o #{opts[:format]} | head -1"
+      "pidof -s #{escape(process)}"
     end
 
     def count(process)
-      "ps aux | grep -w -- #{escape(process)} | grep -v grep | wc -l"
+      "pidof #{escape(process)} | wc -w"
     end
 
     def check_is_running(process)
-      "ps aux | grep -w -- #{escape(process)} | grep -qv grep"
+      "pidof #{escape(process)}"
     end
 
     def check_count(process,count)
-      "test $(ps aux | grep -w -- #{escape(process)} | grep -v grep | wc -l) -eq #{escape(count)}"
+      "test $(pidof #{escape(process)} | wc -w) -eq #{escape(count)}"
     end
   end
 end

--- a/lib/specinfra/command/darwin/base/process.rb
+++ b/lib/specinfra/command/darwin/base/process.rb
@@ -1,7 +1,19 @@
 class Specinfra::Command::Darwin::Base::Process < Specinfra::Command::Base::Process
   class << self
     def get(process, opts)
-      "ps -A -c -o #{opts[:format]},command | grep -E -m 1 ^\\ *[0-9]+\\ +#{escape(process)}$ | awk '{print $1}'"
+      "pgrep -x #{escape(process)} | head -1"
+    end
+
+    def count(process)
+      "pgrep -x #{escape(process)} | wc -l"
+    end
+
+    def check_is_running(process)
+      "pgrep -q -x #{escape(process)}"
+    end
+
+    def check_count(process,count)
+      "test $(pgrep -x #{escape(process)} | wc -l) -eq #{escape(count)}"
     end
   end
 end

--- a/lib/specinfra/command/freebsd/base/process.rb
+++ b/lib/specinfra/command/freebsd/base/process.rb
@@ -1,19 +1,19 @@
 class Specinfra::Command::Freebsd::Base::Process < Specinfra::Command::Base::Process
   class << self
     def get(process, opts)
-      "ps -p `pgrep -xn #{escape(process)}` -o #{opts[:format]}"
+      "pgrep -x #{escape(process)} | head -1"
     end
 
     def count(process)
-      "pgrep #{escape(process)} | wc -l"
+      "pgrep -x #{escape(process)} | wc -l"
     end
 
     def check_is_running(process)
-      "pgrep -q #{escape(process)}"
+      "pgrep -q -x #{escape(process)}"
     end
 
     def check_count(process,count)
-      "test `pgrep #{escape(process)} | wc -l` -eq #{escape(count)}"
+      "test `pgrep -x #{escape(process)} | wc -l` -eq #{escape(count)}"
     end
   end
 end

--- a/spec/command/base/process_spec.rb
+++ b/spec/command/base/process_spec.rb
@@ -3,5 +3,5 @@ require 'spec_helper'
 set :os, { :family => nil }
 
 describe get_command(:count_process, 'foo') do
-  it { should eq 'ps aux | grep -w -- foo | grep -v grep | wc -l' }
+  it { should eq 'pidof foo | wc -w' }
 end

--- a/spec/command/darwin/process_spec.rb
+++ b/spec/command/darwin/process_spec.rb
@@ -3,5 +3,5 @@ require 'spec_helper'
 set :os, { :family => 'darwin' }
 
 describe get_command(:get_process, 'Google Chrome', :format => 'pid=') do
-  it { should eq "ps -A -c -o pid=,command | grep -E -m 1 ^\\ *[0-9]+\\ +Google\\ Chrome$ | awk '{print $1}'" }
+  it { should eq "pgrep -x Google\\ Chrome | head -1" }
 end


### PR DESCRIPTION
Hi @mizzy, I had some trouble while I was checking services:
 * Check if service 'srv1' is running catches 'srv10'
 * Check if service 'srv' is running catches other processes with srv in ther name and or params (any output from `ps aux`)

I was not able to test everything in their proper env, but **freebsd** should be similar to  **darwin**.