### PR TITLE
[WIP] Raise error when os detection failed

### DIFF
--- a/lib/specinfra/backend/base.rb
+++ b/lib/specinfra/backend/base.rb
@@ -32,6 +32,7 @@ module Specinfra
             @os_info[:arch] ||= self.run_command('uname -m').stdout.strip
             return @os_info
           end
+          raise NotImplementedError, 'OS detection failed.'
         end
       end
 


### PR DESCRIPTION
just same as:
https://github.com/mizzy/specinfra/pull/392

fix this problem:
If all os detection failed, return values are a list (Specinfra::Helper::DetectOs.subclasses.)
When getting os[:family] in *_spec.rb it put out an error
"TypeError: no implicit conversion of Symbol into Integer"
It's very hard to know the failure of os detection.

But it breaks tests... There's something wrong.

```
$ bundle exec rake spec:backend
.........FFFF......FFFFFFFFFF..
Failures:

  1) os test ubuntu with lsb_release command
     Failure/Error: raise NotImplementedError, 'OS detection failed.'

     NotImplementedError:
       OS detection failed.
     # ./lib/specinfra/backend/base.rb:35:in `block in os_info'
     # ./lib/specinfra/backend/base.rb:30:in `each'
     # ./lib/specinfra/backend/base.rb:30:in `os_info'
     # ./lib/specinfra/helper/os.rb:9:in `os'
     # ./spec/backend/exec/build_command_spec.rb:135:in `block (3 levels) in <top (required)>'

(omitted below)
```