### PR TITLE
support Amazon Linux 2 systemd init system

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -114,6 +114,10 @@ require 'specinfra/command/eos/base'
 require 'specinfra/command/amazon'
 require 'specinfra/command/amazon/base'
 
+# Amazon Linux V2 (inherit RedHat)
+require 'specinfra/command/amazon/v2'
+require 'specinfra/command/amazon/v2/service'
+
 # AIX (inherit Base)
 require 'specinfra/command/aix'
 require 'specinfra/command/aix/base'

--- a/lib/specinfra/command/amazon/v2.rb
+++ b/lib/specinfra/command/amazon/v2.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Amazon::V2 < Specinfra::Command::Redhat::Base
+end

--- a/lib/specinfra/command/amazon/v2/service.rb
+++ b/lib/specinfra/command/amazon/v2/service.rb
@@ -1,0 +1,5 @@
+class Specinfra::Command::Amazon::V2::Service < Specinfra::Command::Amazon::Base::Service
+  class << self
+    include Specinfra::Command::Module::Systemd
+  end
+end

--- a/spec/command/amazon2/service_spec.rb
+++ b/spec/command/amazon2/service_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'amazon', :release => '2'
+
+describe get_command(:enable_service, 'httpd') do
+  it { should eq 'systemctl enable httpd' }
+end
+
+describe get_command(:disable_service, 'httpd') do
+  it { should eq 'systemctl disable httpd' }
+end
+
+describe get_command(:start_service, 'httpd') do
+  it { should eq 'systemctl start httpd' }
+end
+
+describe get_command(:stop_service, 'httpd') do
+  it { should eq 'systemctl stop httpd' }
+end
+
+describe get_command(:restart_service, 'httpd') do
+  it { should eq 'systemctl restart httpd' }
+end
+
+describe get_command(:reload_service, 'httpd') do
+  it { should eq 'systemctl reload httpd' }
+end
+
+describe get_command(:enable_service, 'sshd.socket') do
+  it { should eq 'systemctl enable sshd.socket' }
+end


### PR DESCRIPTION
There are probably some more differences between amazon linux v1 and v2, but this is the biggest one that can cause some downstream libraries (in my case, serverspec) to make incorrect calls to `service` when on Amazon Linux 2.

I mostly borrowed from how redhat v7 is differentiated, though I'm fine with whichever way we do it, as long as specinfra knows the right init system to use.