### PR TITLE
Refine method get_table()

### DIFF
--- a/lib/specinfra/command/base/cron.rb
+++ b/lib/specinfra/command/base/cron.rb
@@ -11,7 +11,7 @@ class Specinfra::Command::Base::Cron < Specinfra::Command::Base
     end
 
     def get_table
-      'crontab -l'
+      'cat /etc/cron.d/* /etc/crontab /var/spool/cron/* /var/spool/cron/crontabs/* 2> /dev/null'
     end
   end
 end


### PR DESCRIPTION
(Sorry for many times.)
This is a pull request to refine method get_table() to check all cron tables specified by Vixie Cron.
Thanks a lot.