### PR TITLE
Detect qemu virtualization as well

### DIFF
--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -17,7 +17,7 @@ module Specinfra
 
         cmd = backend.command.get(:get_inventory_system_product_name)
         ret = backend.run_command(cmd)
-        if ret.exit_status == 0
+        if ret.exit_status == 0 and ret.stdout.length > 0
            res[:system] = parse_system_product_name(ret.stdout)
            return res
         end
@@ -50,7 +50,7 @@ module Specinfra
         detected = ret.strip
 
         case detected
-        when 'vmware', 'kvm'
+        when 'vmware', 'kvm', 'qemu'
           detected
         when 'oracle'
           'vbox'


### PR DESCRIPTION
KVM is already detected but sometimes we want to run systems with full
CPU emulation and have them spec'ed as well.

We check for empty dmidecode output since e.g. the arm machines may
return empty information.