### PR TITLE
Allow to customize which option the shell to use to execute a command

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -45,7 +45,7 @@ module Specinfra
           shell_options << "-l"
         end
         
-        shell << ' ' << shell_options.join(' ') if shell_options.any?
+        shell << ' ' << shell_options.join(' ') unless shell_options.empty?
         
         command_option = get_config(:command_option) || '-c'
         command_option = command_option.shellescape

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -33,14 +33,19 @@ module Specinfra
         shell = get_config(:shell) || '/bin/sh'
         cmd = cmd.shelljoin if cmd.is_a?(Array)
         shell = shell.shellescape
+        
+        shell_options = get_config(:shell_options) || []
+        shell_options = shell_options.split ' ' if not shell_options.is_a?(Array)
 
-        if get_config(:interactive_shell)
-          shell << " -i"
+        if get_config(:interactive_shell) and not shell_options.include?('-i')
+          shell_options << "-i"
         end
 
-        if get_config(:login_shell)
-          shell << " -l"
+        if get_config(:login_shell) and not shell_options.include?('-l')
+          shell_options << " -l"
         end
+        
+        shell << ' ' << shell_options.join(' ') if shell_options.any?
         
         command_option = get_config(:command_option) || '-c'
         command_option = command_option.shellescape

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -30,12 +30,13 @@ module Specinfra
       end
 
       def build_command(cmd)
+        shell_escaping = get_config(:shell_escaping) || true
         shell = get_config(:shell) || '/bin/sh'
         cmd = cmd.shelljoin if cmd.is_a?(Array)
-        shell = shell.shellescape
-        
+        shell = shell.shellescape if shell_escaping
+
         shell_options = get_config(:shell_options) || []
-        shell_options = shell_options.split ' ' if not shell_options.is_a?(Array)
+        shell_options = shell_options.shellsplit unless shell_options.is_a?(Array)
 
         if get_config(:interactive_shell) and not shell_options.include?('-i')
           shell_options << "-i"
@@ -44,13 +45,14 @@ module Specinfra
         if get_config(:login_shell) and not shell_options.include?('-l')
           shell_options << "-l"
         end
-        
-        shell << ' ' << shell_options.join(' ') unless shell_options.empty?
-        
-        command_option = get_config(:command_option) || '-c'
-        command_option = command_option.shellescape
 
-        cmd = "#{shell} #{command_option} #{cmd.to_s.shellescape}"
+        shell << ' ' << shell_options.shelljoin unless shell_options.empty?
+
+        command_option = get_config(:command_option) || '-c'
+        command_option = command_option.shellescape if shell_escaping
+
+        cmd = cmd.to_s.shellescape if shell_escaping
+        cmd = "#{shell} #{command_option} #{cmd.to_s}"
 
         path = get_config(:path)
         if path

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -41,8 +41,10 @@ module Specinfra
         if get_config(:login_shell)
           shell << " -l"
         end
+        
+        command_option = get_config(:command_option).shellescape || '-c'
 
-        cmd = "#{shell} -c #{cmd.to_s.shellescape}"
+        cmd = "#{shell} #{command_option} #{cmd.to_s.shellescape}"
 
         path = get_config(:path)
         if path

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -42,7 +42,8 @@ module Specinfra
           shell << " -l"
         end
         
-        command_option = get_config(:command_option).shellescape || '-c'
+        command_option = get_config(:command_option) || '-c'
+        command_option = command_option.shellescape
 
         cmd = "#{shell} #{command_option} #{cmd.to_s.shellescape}"
 

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -42,7 +42,7 @@ module Specinfra
         end
 
         if get_config(:login_shell) and not shell_options.include?('-l')
-          shell_options << " -l"
+          shell_options << "-l"
         end
         
         shell << ' ' << shell_options.join(' ') if shell_options.any?

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -30,7 +30,8 @@ module Specinfra
       end
 
       def build_command(cmd)
-        shell_escaping = get_config(:shell_escaping) || true
+        shell_escaping = get_config(:shell_escaping)
+        shell_escaping = true if shell_escaping.nil?
         shell = get_config(:shell) || '/bin/sh'
         cmd = cmd.shelljoin if cmd.is_a?(Array)
         shell = shell.shellescape if shell_escaping

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -6,6 +6,7 @@ module Specinfra
         :env,
         :path,
         :shell,
+        :shell_escaping,
         :shell_options,
         :command_option,
         :interactive_shell,

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -6,6 +6,8 @@ module Specinfra
         :env,
         :path,
         :shell,
+        :shell_options,
+        :command_option,
         :interactive_shell,
         :login_shell,
         :pre_command,


### PR DESCRIPTION
I have a use case where I need to use firejail instead of bash to execute a command. 
I'd rather use `/usr/bin/firejail --queit --` instead of `/usr/bin/firejail --quiet -c`. This PR allows me to do that.