### PR TITLE
Allow to check if a package is installed by pip3

### DIFF
--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -41,6 +41,13 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
       cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
       cmd
     end
+    
+    def check_is_installed_by_pip3(name, version=nil)
+      regexp = "^#{name} "
+      cmd = "pip3 list | grep -iw -- #{escape(regexp)}"
+      cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
+      cmd
+    end
 
     def check_is_installed_by_cpan(name, version=nil)
       regexp = "^#{name}"


### PR DESCRIPTION
Right now you usually have two Python versions installed and both exist in your path.
This PR allows you to check if a package is installed by pip into a Python 3 interpreter.