### PR TITLE
Add condition for Amazon Linux 2

### DIFF
--- a/lib/specinfra/helper/detect_os/redhat.rb
+++ b/lib/specinfra/helper/detect_os/redhat.rb
@@ -19,6 +19,8 @@ class Specinfra::Helper::DetectOs::Redhat < Specinfra::Helper::DetectOs
       line = run_command('cat /etc/system-release').stdout
       if line =~ /release (\d[\d.]*)/
         release = $1
+      elsif line =~ /Amazon Linux (\d+)/
+        release = $1
       end
       { :family => 'amazon', :release => release }
     end


### PR DESCRIPTION
I found the current logic is insufficient to detect os for amazon linux 2, because:

```
$ cat /etc/system-release
Amazon Linux 2
```

without this patch, you get os like this:

```
{:family=>"amazon", :release=>nil, :arch=>"x86_64"} 
```
