### PR TITLE
Fix check_is_installed_by_pip regex

### DIFF
--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -36,7 +36,7 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
     end
 
     def check_is_installed_by_pip(name, version=nil)
-      regexp = "^#{name} "
+      regexp = "^#{name}"
       cmd = "pip list | grep -iw -- #{escape(regexp)}"
       cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
       cmd


### PR DESCRIPTION
Currently used regex for matching output for pip fails for following `pip list` output:

```
Package                          Version
-------------------------------- ---------
pip                              10.0.1
ply                              3.4
policycoreutils-default-encoding 0.1
pyasn1                           0.4.3
pycparser                        2.14
pycrypto                         2.6.1
```


When checking for `policycoreutils-default-encoding` grep, having both space at the end of regex and `-w` switch enabled expects to find 2 whitespaces after the package name (and it finds 1).

My fix removes space in the regex and lets `-w` switch to do its job.
