### PR TITLE
allow to use net-ssh-5.0

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-scp"
-  spec.add_runtime_dependency "net-ssh", ">= 2.7", "< 5.0"
+  spec.add_runtime_dependency "net-ssh", ">= 2.7"
   spec.add_runtime_dependency "net-telnet"
   spec.add_runtime_dependency "sfl"
 


### PR DESCRIPTION
When I update vagrant-itamae plugin, a conflict occurs as follows.

```
% vagrant plugin update
Updating installed plugins...
Bundler, the underlying system Vagrant uses to install plugins,
reported an error. The error is shown below. These errors are usually
caused by misconfigured plugin installations or transient network
issues. The error from Bundler is:

conflicting dependencies net-ssh (= 4.2.0) and net-ssh (= 5.0.1)
  Activated net-ssh-5.0.1
  which does not match conflicting dependency (= 4.2.0)

  Conflicting dependency chains:
    net-ssh (= 5.0.1), 5.0.1 activated

  versus:
    net-ssh (= 4.2.0)

  Gems matching net-ssh (= 4.2.0):
    net-ssh-4.2.0
```

This is because specinfra requires net-ssh-4.2
but net-scp allows to use net-ssh-5.0.

I seems specinfa works with net-ssh-5.0.
All specs have passed.

Please allow to use net-ssh-5.0.
