### PR TITLE
Use `ss` when Ubuntu v18

### DIFF
--- a/lib/specinfra/command/ubuntu/base/port.rb
+++ b/lib/specinfra/command/ubuntu/base/port.rb
@@ -1,0 +1,11 @@
+class Specinfra::Command::Ubuntu::Base::Port < Specinfra::Command::Linux::Base::Port
+  class << self
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_i < 18
+        self
+      else
+        Specinfra::Command::Ubuntu::V18::Port
+      end
+    end
+  end
+end

--- a/lib/specinfra/command/ubuntu/v18.rb
+++ b/lib/specinfra/command/ubuntu/v18.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Ubuntu::V18 < Specinfra::Command::Ubuntu::Base; end

--- a/lib/specinfra/command/ubuntu/v18/port.rb
+++ b/lib/specinfra/command/ubuntu/v18/port.rb
@@ -1,0 +1,5 @@
+class Specinfra::Command::Ubuntu::Base::V18::Port < Specinfra::Command::Ubuntu::Base::Port
+  class << self
+    include Specinfra::Command::Module::Ss
+  end
+end


### PR DESCRIPTION
I ran specs on Ubuntu 18 Server but failed be_listening as `netstat` is not installed by minimal install.
So I modified Ubuntu 18 to use the `ss` command instead of` netstat`.