### PR TITLE
Use ss for Amazon Linux 2, instead of netstat

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -117,6 +117,7 @@ require 'specinfra/command/amazon/base'
 # Amazon Linux V2 (inherit RedHat)
 require 'specinfra/command/amazon/v2'
 require 'specinfra/command/amazon/v2/service'
+require 'specinfra/command/amazon/v2/port'
 
 # AIX (inherit Base)
 require 'specinfra/command/aix'

--- a/lib/specinfra/command/amazon/v2/port.rb
+++ b/lib/specinfra/command/amazon/v2/port.rb
@@ -1,0 +1,5 @@
+class Specinfra::Command::Amazon::V2::Port < Specinfra::Command::Amazon::Base::Port
+  class << self
+    include Specinfra::Command::Module::Ss
+  end
+end

--- a/spec/command/amazon2/port_spec.rb
+++ b/spec/command/amazon2/port_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'amazon', :release => '2'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq 'ss -tunl | grep -- :80\ ' }
+end


### PR DESCRIPTION
Amazon Linux 2 requires use of `ss` for port checking, just like RHEL 7.