### PR TITLE
pin `net-telnet` dependency to keep ruby support for < 2.3

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -18,10 +18,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  # TODO: at some point pin to a minumum version of ruby to reduce support burden in a major version bump
+  # spec.required_ruby_version  = '>= 2.3.0'
 
   spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "net-ssh", ">= 2.7"
-  spec.add_runtime_dependency "net-telnet"
+  # TODO: remove the lock when you want to ruby ruby < 2.3 support
+  spec.add_runtime_dependency "net-telnet", "0.1.1"
   spec.add_runtime_dependency "sfl"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Also added todo comments to come back and remove it at a later date and to pin to a min version of ruby at some point.

in version [version 0.2.0]([here](https://github.com/ruby/net-telnet/commit/4b5432a1d4f81e6c56bac6e72b0fe27bb8a6dfd8#diff-de0020d29d91153b0fe757ca69118a4e)) they dropped ruby version support for `< 2.3`. Pinning to `0.1.1` allows older setups to keep working and then can then be removed at the time in which the version of ruby this gem supports is declared in a major release.

Affects:
- https://github.com/sensu-plugins/sensu-plugins-logs/pull/34
- https://github.com/sensu-plugins/sensu-plugins-docker/pull/69

I plan on dropping those versions of ruby versions in the next major releases of those gems.

Signed-off-by: Ben Abrams <me@benabrams.it>