### PR TITLE
Reduce the number of files that ship in the gem artifact

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -13,17 +13,15 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/mizzy/specinfra'
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.files.delete('wercker.yml')
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = %w{LICENSE.txt README.md} + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:lib/)}i }
+  spec.test_files    = %w{Gemfile specinfra.gemspec Rakefile} + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:spec/)}i }
   spec.require_paths = ["lib"]
   # TODO: at some point pin to a minumum version of ruby to reduce support burden in a major version bump
   # spec.required_ruby_version  = '>= 2.3.0'
 
   spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "net-ssh", ">= 2.7"
-  # TODO: remove the lock when you want to ruby ruby < 2.3 support
+  # TODO: remove the lock when you want to remove ruby < 2.3 support
   spec.add_runtime_dependency "net-telnet", "0.1.1"
   spec.add_runtime_dependency "sfl"
 


### PR DESCRIPTION
Since the install is really just an artifact buried deep on a user's system there's no need to ship the full test suite and documentation. This reduces the install size, especially for packaged products that use this gem.