### PR TITLE
Remove port test config that uses ss command for RedHat 7

### DIFF
--- a/lib/specinfra/command/redhat/v7/port.rb
+++ b/lib/specinfra/command/redhat/v7/port.rb
@@ -1,5 +1,0 @@
-class Specinfra::Command::Redhat::V7::Port < Specinfra::Command::Redhat::Base::Port
-  class << self
-    include Specinfra::Command::Module::Ss
-  end
-end


### PR DESCRIPTION
- The port test which uses `ss` does not work on RedHat7
- The base port test for uses `netstat` and that works fine