### PR TITLE
Remove port test config that uses ss command for RedHat 7

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -95,7 +95,6 @@ require 'specinfra/command/redhat/v5/iptables'
 require 'specinfra/command/redhat/v7'
 require 'specinfra/command/redhat/v7/host'
 require 'specinfra/command/redhat/v7/service'
-require 'specinfra/command/redhat/v7/port'
 
 # Fedora (inherit RedhHat)
 require 'specinfra/command/fedora'

--- a/lib/specinfra/command/redhat/v7/port.rb
+++ b/lib/specinfra/command/redhat/v7/port.rb
@@ -1,5 +1,0 @@
-class Specinfra::Command::Redhat::V7::Port < Specinfra::Command::Redhat::Base::Port
-  class << self
-    include Specinfra::Command::Module::Ss
-  end
-end

--- a/spec/command/redhat7/port_spec.rb
+++ b/spec/command/redhat7/port_spec.rb
@@ -4,5 +4,5 @@ property[:os] = nil
 set :os, :family => 'redhat', :release => '7'
 
 describe get_command(:check_port_is_listening, '80') do
-  it { should eq 'ss -tunl | grep -- :80\ ' }
+  it { should eq 'netstat -tunl | grep -- :80\ ' }
 end


### PR DESCRIPTION
* The port test which uses ss does not work on RedHat7
* The base port test for uses netstat and that works fine