### PR TITLE
Use built-in enabled check in FreeBSD's service command

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -264,18 +264,22 @@ require 'specinfra/command/freebsd/base/zfs'
 require 'specinfra/command/freebsd/v6'
 require 'specinfra/command/freebsd/v6/user'
 require 'specinfra/command/freebsd/v6/package'
+require 'specinfra/command/freebsd/v6/service'
 
 # FreeBSD V7 (inherit FreeBSD)
 require 'specinfra/command/freebsd/v7'
 require 'specinfra/command/freebsd/v7/package'
+require 'specinfra/command/freebsd/v7/service'
 
 # FreeBSD V8 (inherit FreeBSD)
 require 'specinfra/command/freebsd/v8'
 require 'specinfra/command/freebsd/v8/package'
+require 'specinfra/command/freebsd/v8/service'
 
 # FreeBSD V9 (inherit FreeBSD)
 require 'specinfra/command/freebsd/v9'
 require 'specinfra/command/freebsd/v9/package'
+require 'specinfra/command/freebsd/v9/service'
 
 # FreeBSD V11 (inherit FreeBSD)
 require 'specinfra/command/freebsd/v11'

--- a/lib/specinfra/command/freebsd/base/service.rb
+++ b/lib/specinfra/command/freebsd/base/service.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Freebsd::Base::Service < Specinfra::Command::Base::Service
   class << self
     def check_is_enabled(service, level=3)
-      "service -e | grep -- #{escape(service)}"
+      "service #{escape(service)} enabled"
     end
     def check_is_running_under_init(service)
       "service #{escape(service)} status | grep -E 'as (pid [0-9]+)'"

--- a/lib/specinfra/command/freebsd/v6/service.rb
+++ b/lib/specinfra/command/freebsd/v6/service.rb
@@ -1,0 +1,7 @@
+class Specinfra::Command::Freebsd::V6::Service < Specinfra::Command::Base::Service
+  class << self
+    def check_is_enabled(service, level=3)
+      "service -e | grep -- /#{escape(service)}$"
+    end
+  end
+end

--- a/lib/specinfra/command/freebsd/v7/service.rb
+++ b/lib/specinfra/command/freebsd/v7/service.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Freebsd::V7::Service < Specinfra::Command::Freebsd::V6::Service
+end

--- a/lib/specinfra/command/freebsd/v8/service.rb
+++ b/lib/specinfra/command/freebsd/v8/service.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Freebsd::V8::Service < Specinfra::Command::Freebsd::V7::Service
+end

--- a/lib/specinfra/command/freebsd/v9/service.rb
+++ b/lib/specinfra/command/freebsd/v9/service.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Freebsd::V9::Service < Specinfra::Command::Freebsd::V8::Service
+end

--- a/spec/command/freebsd/service_spec.rb
+++ b/spec/command/freebsd/service_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe 'command/freebsd/service works correctly' do
+  before do
+    property[:os] = nil
+  end
+
+  context 'freebsd-base' do
+    before do
+      set :os, :family => 'freebsd'
+    end
+    describe 'get_command(:check_service_is_enabled, "httpd")' do
+      it { expect(get_command(:check_service_is_enabled, 'httpd')).to eq 'service httpd enabled' }
+    end
+  end
+
+  context 'freebsd-6' do
+    before do
+      set :os, :family => 'freebsd', :release => '6'
+    end
+    describe 'get_command(:check_service_is_enabled, "httpd")' do
+      it { expect(get_command(:check_service_is_enabled, 'httpd')).to eq 'service -e | grep -- /httpd$' }
+    end
+  end
+
+  context 'freebsd-7' do
+    before do
+      set :os, :family => 'freebsd', :release => '7'
+    end
+    describe 'get_command(:check_service_is_enabled, "httpd")' do
+      it { expect(get_command(:check_service_is_enabled, 'httpd')).to eq 'service -e | grep -- /httpd$' }
+    end
+  end
+
+  context 'freebsd-8' do
+    before do
+      set :os, :family => 'freebsd', :release => '8'
+    end
+    describe 'get_command(:check_service_is_enabled, "httpd")' do
+      it { expect(get_command(:check_service_is_enabled, 'httpd')).to eq 'service -e | grep -- /httpd$' }
+    end
+  end
+
+  context 'freebsd-9' do
+    before do
+      set :os, :family => 'freebsd', :release => '9'
+    end
+    describe 'get_command(:check_service_is_enabled, "httpd")' do
+      it { expect(get_command(:check_service_is_enabled, 'httpd')).to eq 'service -e | grep -- /httpd$' }
+    end
+  end
+
+  context 'freebsd-10' do
+    before do
+      set :os, :family => 'freebsd', :release => '10'
+    end
+    describe 'get_command(:check_service_is_enabled, "httpd")' do
+      it { expect(get_command(:check_service_is_enabled, 'httpd')).to eq 'service httpd enabled' }
+    end
+  end
+
+  context 'freebsd-11' do
+    before do
+      set :os, :family => 'freebsd', :release => '11'
+    end
+    describe 'get_command(:check_service_is_enabled, "httpd")' do
+      it { expect(get_command(:check_service_is_enabled, 'httpd')).to eq 'service httpd enabled' }
+    end
+  end
+end
+


### PR DESCRIPTION
I ran into an issue in serverspec checking that a service is not enabled on FreeBSD. If `openntpd` is enabled but `ntpd` is not, the following serverspec test fails when it should pass:

```
describe service('ntpd') do
  it { should_not be_enabled }
end
```

This is because the regex `ntpd` matches `openntpd`, which is bad luck for me!

Initially I was attempting to improve the regex, but while reading the docs I found that [`service` supports an `enabled` command](https://www.freebsd.org/cgi/man.cgi?query=rc&apropos=0&sektion=8&manpath=FreeBSD+10.0-RELEASE&arch=default&format=html) which looks like exactly what is needed here:

```
	   enabled  Return 0 if	the service is enabled and 1 if	it is not.
		    This command does not print	anything.
```

That's what I've used here, and in my own testing this behaves as expected.

It does appear this is new to FreeBSD 10.0, as I don't see it in the [man page for 9.3 or earlier](https://www.freebsd.org/cgi/man.cgi?query=rc&apropos=0&sektion=8&manpath=FreeBSD+9.3-RELEASE&arch=default&format=html), so I think at minimum more work is needed to maintain compatibility with older versions before this could be merged.