### PR TITLE
Check if services are running on FreeBSD more precisely

### DIFF
--- a/lib/specinfra/command/freebsd/base/service.rb
+++ b/lib/specinfra/command/freebsd/base/service.rb
@@ -3,8 +3,8 @@ class Specinfra::Command::Freebsd::Base::Service < Specinfra::Command::Base::Ser
     def check_is_enabled(service, level=3)
       "service -e | grep -- #{escape(service)}"
     end
-    def check_is_running_under_init(service)
-      "service #{escape(service)} status | grep -E 'as (pid [0-9]+)'"
+    def check_is_running(service)
+      "service #{escape(service)} onestatus"
     end
   end
 end

--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -9,11 +9,11 @@ module Specinfra
       # So return false if stdout contains "stopped/waiting" or "stop/waiting".
       return false if ret.stdout =~ /stop(ped)?\/waiting/
 
-      # If the service is not registered, check by ps command
-      if ret.exit_status == 1
-        cmd = Specinfra.command.get(:check_process_is_running, service)
-        ret = Specinfra.backend.run_command(cmd)
-      end
+      # # If the service is not registered, check by ps command
+      # if ret.exit_status == 1
+      #   cmd = Specinfra.command.get(:check_process_is_running, service)
+      #   ret = Specinfra.backend.run_command(cmd)
+      # end
 
       ret.success?
     end


### PR DESCRIPTION
I ran into an issue when using serverspec with FreeBSD and asserting that the service ntp is not running, which then spiralled into several issues:

1. The service check doesn't work in all situations (this is the issue I ran into originally). On FreeBSD, if you call `service status <service>` for a service that isn't enabled, it errors but returns a status code of 0:

   ```
   $ service ntpd status
   Cannot 'status' ntpd. Set ntpd_enable to YES in /etc/rc.conf or use 'onestatus' instead of 'status'.
   $ echo $?
   0
   ```

   As the message says, this is fixed with the `onestatus` command, which will work as expected whether or not the service is enabled, and I've updated the check to use this command. I've also removed the grep which I don't think is needed, as both `status` and `onestatus` return 0 if the service is running and 1 if it isn't (or if there's another problem, like it isn't registered).

2. The `check_is_running_under_init` override for FreeBSD services doesn't seem to be in play at all? Currently the `check_is_running_under_init` method defined in the init service module runs instead (by way of the `check_is_running` in the base service command). I think the right answer here is to rename it to match `check_is_enabled`, which I've done in this patch.

3. The logic in the Processor is making it hard for me to check if this service is running. If the check via the service module fails, it's checking again with the process module, assuming that the process name will match the service name. I don't know whether or not this is true on other OSes, but it's certainly not true on FreeBSD - for example, the process name for the "openntpd" service is "ntpd". This means that if I assert that the service "ntpd" is not running, the check will fail because the process "ntpd" from the service "openntpd" is running.

   The comment on this logic - "If the service is not registered" - does not match the behaviour either, as it runs if the status check returns 1 for any reason, not just not being registered. I'm not sure what to do here, obviously commenting out the code is not the right thing to merge but I want to start a conversation on this :)
