### PR TITLE
Fix debian package version check for "hold" packages

### DIFF
--- a/lib/specinfra/command/debian/base/package.rb
+++ b/lib/specinfra/command/debian/base/package.rb
@@ -22,7 +22,7 @@ class Specinfra::Command::Debian::Base::Package < Specinfra::Command::Linux::Bas
     end
 
     def get_version(package, opts=nil)
-      "dpkg-query -f '${Status} ${Version}' -W #{package} | sed -n 's/^install ok installed //p'"
+      "dpkg-query -f '${Status} ${Version}' -W #{package} | sed -n 's/^install ok installed \\|hold ok installed //p'"
     end
 
     def remove(package, option='')

--- a/spec/command/debian/package_spec.rb
+++ b/spec/command/debian/package_spec.rb
@@ -30,3 +30,7 @@ describe get_command(:install_package, 'linux-headers-$(uname -r)') do
     should eq "DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'  install linux-headers-\\$\\(uname\\ -r\\)"
   end
 end
+
+describe get_command(:get_package_version, 'telnet') do
+  it { should eq "dpkg-query -f '${Status} ${Version}' -W telnet | sed -n 's/^install ok installed \\|hold ok installed //p'" }
+end


### PR DESCRIPTION
The current implementation would work for dpkg-query output such as:

```
> dpkg-query -f '${Status} ${Version}' -W docker-ce
install ok installed 18.06.0~ce~3-0~
```

But not for held packages via `apt-mark hold <package_name>`:

```
> dpkg-query -f '${Status} ${Version}' -W kubelet
hold ok installed 1.12.1-00
```