### PR TITLE
add option :volume to set as dockervolume when starting the container

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -67,6 +67,10 @@ module Specinfra
         env = get_config(:env).to_a.map { |v| v.join('=') }
         opts['Env'] = opts['Env'].to_a.concat(env)
 
+        if !get_config(:volume).nil?
+          opts['Binds'] = [get_config(:volume)]
+        end
+
         opts.merge!(get_config(:docker_container_create_options) || {})
 
         @container = ::Docker::Container.create(opts)


### PR DESCRIPTION
I want to start the conterier during serverspec test with some volume containing data for the test not inside the docker container.

The configuration in the rspec would look like this:
set :volume, Dir.pwd + "/spec/Volume:/local/src"