### PR TITLE
Support for group names with spaces

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -153,12 +153,12 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
     def change_owner(file, owner, group=nil, options = {})
       option = '-R' if options[:recursive]
       owner = "#{owner}:#{group}" if group
-      "chown #{option} #{owner} #{escape(file)}".squeeze(' ')
+      "chown #{option} #{escape(owner)} #{escape(file)}".squeeze(' ')
     end
 
     def change_group(file, group, options = {})
       option = '-R' if options[:recursive]
-      "chgrp #{option} #{group} #{escape(file)}".squeeze(' ')
+      "chgrp #{option} #{escape(group)} #{escape(file)}".squeeze(' ')
     end
 
     def create_as_directory(file)

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -26,12 +26,20 @@ describe get_command(:change_file_owner, '/tmp', 'root', 'root') do
   it { should eq 'chown root:root /tmp' }
 end
 
+describe get_command(:change_file_owner, '/tmp', 'root', 'Domain Users') do
+  it { should eq 'chown root:Domain\\ Users /tmp' }
+end
+
 describe get_command(:change_file_owner, '/tmp', 'root', 'root', :recursive => true) do
   it { should eq 'chown -R root:root /tmp' }
 end
 
 describe get_command(:change_file_group, '/tmp', 'root') do
   it { should eq 'chgrp root /tmp' }
+end
+
+describe get_command(:change_file_group, '/tmp', 'Domain Users') do
+  it { should eq 'chgrp Domain\ Users /tmp' }
 end
 
 describe get_command(:change_file_group, '/tmp', 'root', :recursive => true) do


### PR DESCRIPTION
for example in an environment that used a Windows domain for authentication and authorization.

Similar PRs: #496

seems that it is escaped with other commands([user](https://github.com/mizzy/specinfra/blob/master/lib/specinfra/command/base/user.rb#L12), [group](https://github.com/mizzy/specinfra/blob/master/lib/specinfra/command/base/group.rb#L4)).

Change commands:
  - change_owner(chown)
  - change_group(chgrp)


Example macOS Mojave(10.14.1):

```shell
$ id
uid=1826461152(hiroki.ohtsuka) gid=788986963(INTRA\Domain Users) groups=788986963(INTRA\Domain Users),12(everyone) ...
```

Previously:

```shell
$ chown hiroki.ohtsuka:INTRA\Domain Users /tmp/foobar
chown: INTRADomain: illegal group name
$ chgrp INTRA\Domain Users /tmp/foobar
chgrp: INTRADomain: illegal group name
```

Improved command:

```shell
$ chown hiroki.ohtsuka:INTRA\\Domain\ Users /tmp/itamae
$ echo $?
0
$ chgrp INTRA\\Domain\ Users /tmp/foobar
$ echo $?
0
```