### PR TITLE
Update so the 'check_is_enabled' works for all SLES versions

### DIFF
--- a/lib/specinfra/command/suse/base/service.rb
+++ b/lib/specinfra/command/suse/base/service.rb
@@ -3,6 +3,14 @@ class Specinfra::Command::Suse::Base::Service < Specinfra::Command::Linux::Base:
     def check_is_enabled(service, level=3)
       "chkconfig --list #{escape(service)} | grep #{level}:on"
     end
+
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_i < 12
+        self
+      else
+        Specinfra::Command::Sles::V12::Service
+      end
+    end
   end
 end
 


### PR DESCRIPTION
A simple change to allow an 'is_enabled' check to be run more accurately on SLES 15. Required as certain services, such as 'apache2' have been migrated to systemctl.
Tested out my change by modifying the local gem in my module and seems to work fine.