### PR TITLE
Suppress uninitialized ivar warning

### DIFF
--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -51,7 +51,9 @@ module Specinfra
             instance_variable_set("@#{key}", val)
             RSpec.configuration.send(:"#{key}=", val) if defined?(RSpec)
           end
-          ret = instance_variable_get("@#{key}")
+          if instance_variable_defined?("@#{key}")
+            ret = instance_variable_get("@#{key}")
+          end
         rescue NameError
           ret = nil
         ensure


### PR DESCRIPTION
When Ruby's warning is enabled, the following warning is printed:

```
/home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.6.0/gems/specinfra-2.76.5/lib/specinfra/configuration.rb:54: warning: instance variable @path not initialized
```

It want to fix this to make it easier to read other warnings.