### PR TITLE
Bundler Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3
+  # - 2.3
   - 2.4
   - 2.5
 
 before_install:
   - travis_retry gem update --system 2.7.8
-  - travis_retry gem install bundler
+  - travis_retry gem install bundler -v 1.17.3
 
 script:
   - bundle exec rake spec


### PR DESCRIPTION
As of Bundler 2.0.0 support has been dropped for Ruby less than 2.3 and RubyGems less than 3.0.0 and so have pinned bundler to a working version.
In addition have disabled testing on rvm 2.3 as I was unable to find a version of bundler that it would accept, regardless of what I tried it stated that the version of bundler was incompatible.