### PR TITLE
Add '%' to characters manually escaped in solaris cron check

### DIFF
--- a/lib/specinfra/command/solaris/base/cron.rb
+++ b/lib/specinfra/command/solaris/base/cron.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Solaris::Base::Cron < Specinfra::Command::Base::Cron
   class << self
     def check_has_entry(user, entry)
-        entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]').gsub(/\%/, '\\%')
+      entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]').gsub(/\%/, '\\%')
       if user.nil?
         "crontab -l | grep -- #{escape(entry_escaped)}"
       else

--- a/lib/specinfra/command/solaris/base/cron.rb
+++ b/lib/specinfra/command/solaris/base/cron.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Solaris::Base::Cron < Specinfra::Command::Base::Cron
   class << self
     def check_has_entry(user, entry)
-	    entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]').gsub(/\%/, '\\%')
+        entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]').gsub(/\%/, '\\%')
       if user.nil?
         "crontab -l | grep -- #{escape(entry_escaped)}"
       else

--- a/lib/specinfra/command/solaris/base/cron.rb
+++ b/lib/specinfra/command/solaris/base/cron.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Solaris::Base::Cron < Specinfra::Command::Base::Cron
   class << self
     def check_has_entry(user, entry)
-      entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]')
+	    entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]').gsub(/\%/, '\\%')
       if user.nil?
         "crontab -l | grep -- #{escape(entry_escaped)}"
       else


### PR DESCRIPTION
'%' needs to be manually escaped in the cron entry definition prior to grepping for the string in crontab -l output