### PR TITLE
Output of ss changed in version 4.14; breaks Specinfra::Command::Module::Ss

### DIFF
--- a/lib/specinfra/command/module/ss.rb
+++ b/lib/specinfra/command/module/ss.rb
@@ -3,22 +3,26 @@ module Specinfra
     module Module
       module Ss
         def check_is_listening(port, options={})
-          pattern = ":#{port} "
-          pattern = " #{inaddr_any_to_asterisk(options[:local_address])}#{pattern}" if options[:local_address]
-          "ss #{command_options(options[:protocol])} | grep -- #{escape(pattern)}"
+          if options[:local_address]
+            pattern = inaddr_any_to_asterisk(options[:local_address]).map { |l| " #{l}:#{port} " }
+            pattern = pattern.join('|')
+          else
+            pattern = ":#{port} "
+          end
+          "ss #{command_options(options[:protocol])} | grep -E -- #{escape(pattern)}"
         end
 
         private
 
         # WORKAROUND:
-        #   ss displays "*" instead of "0.0.0.0".
+        #   Older ss versions display "*" instead of "0.0.0.0".
         #   But serverspec validates IP address by `valid_ip_address?` method:
         #     https://github.com/serverspec/serverspec/blob/master/lib/serverspec/type/port.rb
         def inaddr_any_to_asterisk(local_address)
           if local_address == '0.0.0.0'
-            '\*'
+            [ '\*' , '0\.0\.0\.0' ]
           else
-            local_address
+            [ local_address ]
           end
         end
 

--- a/spec/command/amazon2/port_spec.rb
+++ b/spec/command/amazon2/port_spec.rb
@@ -4,5 +4,5 @@ property[:os] = nil
 set :os, :family => 'amazon', :release => '2'
 
 describe get_command(:check_port_is_listening, '80') do
-  it { should eq 'ss -tunl | grep -- :80\ ' }
+  it { should eq 'ss -tunl | grep -E -- :80\ ' }
 end

--- a/spec/command/debian8/port_spec.rb
+++ b/spec/command/debian8/port_spec.rb
@@ -4,5 +4,5 @@ property[:os] = nil
 set :os, :family => 'debian', :release => '8'
 
 describe get_command(:check_port_is_listening, '80') do
-  it { should eq 'ss -tunl | grep -- :80\ ' }
+  it { should eq 'ss -tunl | grep -E -- :80\ ' }
 end

--- a/spec/command/debian9/port_spec.rb
+++ b/spec/command/debian9/port_spec.rb
@@ -4,6 +4,6 @@ property[:os] = nil
 set :os, :family => 'debian', :release => '9'
 
 describe get_command(:check_port_is_listening, '80') do
-  it { should eq 'ss -tunl | grep -- :80\ ' }
+  it { should eq 'ss -tunl | grep -E -- :80\ ' }
 end
 

--- a/spec/command/module/ss_spec.rb
+++ b/spec/command/module/ss_spec.rb
@@ -5,24 +5,24 @@ describe Specinfra::Command::Module::Ss do
     extend Specinfra::Command::Module::Ss
   end
   let(:klass) { Specinfra::Command::Module::Ss::Test }
-  it { expect(klass.check_is_listening('80')).to eq 'ss -tunl | grep -- :80\ ' }
+  it { expect(klass.check_is_listening('80')).to eq 'ss -tunl | grep -E -- :80\ ' }
 
-  it { expect(klass.check_is_listening('80', options={:protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- :80\ ' }
-  it { expect(klass.check_is_listening('80', options={:protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -- :80\ ' }
-  it { expect(klass.check_is_listening('80', options={:protocol => 'udp'})).to eq 'ss -unl4 | grep -- :80\ ' }
-  it { expect(klass.check_is_listening('80', options={:protocol => 'udp6'})).to eq 'ss -unl6 | grep -- :80\ ' }
+  it { expect(klass.check_is_listening('80', options={:protocol => 'tcp'})).to eq 'ss -tnl4 | grep -E -- :80\ ' }
+  it { expect(klass.check_is_listening('80', options={:protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -E -- :80\ ' }
+  it { expect(klass.check_is_listening('80', options={:protocol => 'udp'})).to eq 'ss -unl4 | grep -E -- :80\ ' }
+  it { expect(klass.check_is_listening('80', options={:protocol => 'udp6'})).to eq 'ss -unl6 | grep -E -- :80\ ' }
 
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -- \ \\\\\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ \\\\\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -- \ \\\\\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ \\\\\*:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -- \ \\\\\*:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
 
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl | grep -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp'})).to eq 'ss -unl4 | grep -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl | grep -E -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -E -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -E -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp'})).to eq 'ss -unl4 | grep -E -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -E -- \ 1.2.3.4:80\ ' }
 
   it { expect{klass.check_is_listening('80', options={:protocol => 'bad_proto'})}.to raise_error(ArgumentError, 'Unknown protocol [bad_proto]') }
 end

--- a/spec/command/redhat7/port_spec.rb
+++ b/spec/command/redhat7/port_spec.rb
@@ -4,5 +4,5 @@ property[:os] = nil
 set :os, :family => 'redhat', :release => '7'
 
 describe get_command(:check_port_is_listening, '80') do
-  it { should eq 'ss -tunl | grep -- :80\ ' }
+  it { should eq 'ss -tunl | grep -E -- :80\ ' }
 end


### PR DESCRIPTION
Hey,

I'm opening this empty PR because I'm not quite sure of how to handle this. While developing a change on a unrelated repository (https://github.com/voxpupuli/puppet-rabbitmq/pull/758) which uses specinfra I came across a bug.

The output off ss changed starting with (at least) version 4.14.0. Most certainly due to [this](https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/?id=1267c0b924de0297510efd48f8f849af774be369) change.

In "real life" this look as following:

Ubuntu 16.04 using iproute2/ss in version 4.3.0:
```
root@ubuntu1604-64-1:/# ss -tnl4 | grep 15672
LISTEN     0      128          *:15672                    *:*
root@ubuntu1604-64-1:/# which ss
/bin/ss
root@ubuntu1604-64-1:/# dpkg -S /bin/ss
iproute2: /bin/ss
root@ubuntu1604-64-1:/# dpkg -l | grep iproute2
ii  iproute2                   4.3.0-1ubuntu3.16.04.4                amd64        networking and traffic control tools
root@ubuntu1604-64-1:/# ss -V
ss utility, iproute2-ss151103
```

Ubuntu 18.04 using iproute2/ss in version 4.15.0:
```
root@ubuntu1804-64-1:/# ss -tnl4 | grep 15672
LISTEN   0         128                 0.0.0.0:15672            0.0.0.0:*
root@ubuntu1804-64-1:/# which ss
/bin/ss
root@ubuntu1804-64-1:/# dpkg -S /bin/ss
iproute2: /bin/ss
root@ubuntu1804-64-1:/# dpkg -l | grep iproute2
ii  iproute2                    4.15.0-2ubuntu1                   amd64        networking and traffic control tools
root@ubuntu1804-64-1:/# ss -V
ss utility, iproute2-ss180129
```

This leads to problems with the implemented workaround [here](https://github.com/mizzy/specinfra/blob/7fcb239eb5b4dca705663ca342c405c41a5ffc0c/lib/specinfra/command/module/ss.rb#L17).

My idea is, to somehow call `ss --version` before the command is run and check if the returned version is greater than `171112` (which is the [internally](https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/?id=7d14d00795c334a288f1733bfdabdf363a7f962c) used version number for v4.14.0).

My questions are:
1. Do you think this is a good idea?
2. Do you know a better way to do this?
3. Can you point me in the right direction of how to implement this? I thought about a adding a `initialize()` method but this isn't possible for the module. Adding a function call before `check_is_listening()` seems a little bit to much as it would be called every time a port is checked.

Another idea would be to just extend the regex to `grep -E -- '0.0.0.0:$port|\*:$port'`. But this might lead to wrong tests as both outputs mean something different (see commit message of [1267c0b924de0297510efd48f8f849af774be369](https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/?id=1267c0b924de0297510efd48f8f849af774be369))