### PR TITLE
Support mount inventory

### DIFF
--- a/lib/specinfra/command/linux/base/inventory.rb
+++ b/lib/specinfra/command/linux/base/inventory.rb
@@ -37,5 +37,8 @@ class Specinfra::Command::Linux::Base::Inventory < Specinfra::Command::Base::Inv
       "dmidecode -s system-product-name"
     end 
 
+    def get_mount
+      'cat /proc/mounts'
+    end
   end
 end

--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -17,6 +17,7 @@ module Specinfra
       group
       facter
       ohai
+      mount
     }
 
     include Enumerable

--- a/lib/specinfra/host_inventory/mount.rb
+++ b/lib/specinfra/host_inventory/mount.rb
@@ -1,0 +1,31 @@
+module Specinfra
+  class HostInventory
+    class Mount < Base
+      def get
+        cmd = backend.command.get(:get_inventory_mount)
+        ret = backend.run_command(cmd)
+        if ret.exit_status == 0
+          parse(ret.stdout)
+        else
+          nil
+        end
+      end
+      def parse(ret)
+        mounts = []
+        ret.each_line do |line|
+          mount = {}
+          if line =~ /^(.+)\s+(.+)\s+(.+)\s+(.+)\s+(\d+)\s+(\d+)$/
+            mount['device'] = $1
+            mount['point'] = $2
+            mount['type'] = $3
+            mount['options'] = $4.split(',')
+            mount['dump'] = $5
+            mount['pass'] = $6
+          end
+          mounts << mount
+        end
+        mounts
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR enable you to get content of `/proc/mounts` like this:

```ruby
pp host_inventory['mount']

[{"device"=>"sysfs",
  "point"=>"/sys",
  "type"=>"sysfs",
  "options"=>["rw", "nosuid", "nodev", "noexec", "relatime"],
  "dump"=>"0",   
  "pass"=>"0"},  
 {"device"=>"proc",
  "point"=>"/proc",
  "type"=>"proc",
  "options"=>["rw", "nosuid", "nodev", "noexec", "relatime"],
  "dump"=>"0",   
  "pass"=>"0"},  
 {"device"=>"udev",
  "point"=>"/dev",
  "type"=>"devtmpfs",
  "options"=>
   ["rw",
    "nosuid",
    "relatime",  
    "size=500824k",
    "nr_inodes=125206",
    "mode=755"], 
  "dump"=>"0",   
  "pass"=>"0"},  
 {"device"=>"devpts",
  "point"=>"/dev/pts",
  "type"=>"devpts",
  "options"=>
   ["rw", "nosuid", "noexec", "relatime", "gid=5", "mode=620", "ptmxmode=000"],
  "dump"=>"0",   
  "pass"=>"0"},  
 {"device"=>"tmpfs",
  "point"=>"/run",
  "type"=>"tmpfs",
  "options"=>
   ["rw", "nosuid", "noexec", "relatime", "size=101588k", "mode=755"],
  "dump"=>"0",   
  "pass"=>"0"},  
 {"device"=>"/dev/sda1",
  "point"=>"/",  
  "type"=>"ext4",
  "options"=>["rw", "relatime", "data=ordered"],
  "dump"=>"0",   
  "pass"=>"0"}]
```