### PR TITLE
Support user_max/min_days on SLES 11 + Solaris 11

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -241,6 +241,8 @@ require 'specinfra/command/opensuse/base/service'
 require 'specinfra/command/sles'
 require 'specinfra/command/sles/base'
 require 'specinfra/command/sles/base/service'
+require 'specinfra/command/sles/v11'
+require 'specinfra/command/sles/v11/user'
 require 'specinfra/command/sles/v12'
 require 'specinfra/command/sles/v12/service'
 
@@ -331,6 +333,10 @@ require 'specinfra/command/solaris/v10/group'
 require 'specinfra/command/solaris/v10/host'
 require 'specinfra/command/solaris/v10/package'
 require 'specinfra/command/solaris/v10/user'
+
+# Solaris 11 (inherit Solaris)
+require 'specinfra/command/solaris/v11'
+require 'specinfra/command/solaris/v11/user'
 
 # SmartOS (inherit Solaris)
 require 'specinfra/command/smartos'

--- a/lib/specinfra/command/sles/v11.rb
+++ b/lib/specinfra/command/sles/v11.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Sles::V11 < Specinfra::Command::Sles::Base
+end

--- a/lib/specinfra/command/sles/v11/user.rb
+++ b/lib/specinfra/command/sles/v11/user.rb
@@ -1,0 +1,11 @@
+class Specinfra::Command::Sles::V11::User < Specinfra::Command::Sles::Base::User
+  class << self
+    def get_minimum_days_between_password_change(user)
+      "chage -l #{escape(user)} | sed -n 's/^Minimum://p' | sed 's|^[[:blank:]]*||g'"
+    end
+
+    def get_maximum_days_between_password_change(user)
+      "chage -l #{escape(user)} | sed -n 's/^Maximum://p' | sed 's|^[[:blank:]]*||g'"
+    end
+  end
+end

--- a/lib/specinfra/command/solaris/v11.rb
+++ b/lib/specinfra/command/solaris/v11.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Solaris::V11 < Specinfra::Command::Solaris::Base
+end

--- a/lib/specinfra/command/solaris/v11/user.rb
+++ b/lib/specinfra/command/solaris/v11/user.rb
@@ -1,0 +1,11 @@
+class Specinfra::Command::Solaris::V11::User < Specinfra::Command::Solaris::Base::User
+  class << self
+    def get_minimum_days_between_password_change(user)
+      "passwd -s #{escape(user)} | sed 's/ \\{1,\\}/%/g' | tr '%' '\n' | sed '4q;d'"
+    end
+
+    def get_maximum_days_between_password_change(user)
+      "passwd -s #{escape(user)} | sed 's/ \\{1,\\}/%/g' | tr '%' '\n' | sed '5q;d'"
+    end
+  end
+end

--- a/spec/command/sles11/user_spec.rb
+++ b/spec/command/sles11/user_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'sles', :release => '11'
+
+describe get_command(:get_user_minimum_days_between_password_change, 'foo') do
+  it { should eq "chage -l foo | sed -n 's/^Minimum://p' | sed 's|^[[:blank:]]*||g'" }
+end
+
+describe get_command(:get_user_maximum_days_between_password_change, 'foo') do
+  it { should eq "chage -l foo | sed -n 's/^Maximum://p' | sed 's|^[[:blank:]]*||g'" }
+end

--- a/spec/command/solaris11/user_spec.rb
+++ b/spec/command/solaris11/user_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'solaris', :release => '11'
+
+describe get_command(:get_user_minimum_days_between_password_change, 'foo') do
+  it { should eq "passwd -s foo | sed 's/ \\{1,\\}/%/g' | tr '%' '\n' | sed '4q;d'" }
+end
+
+describe get_command(:get_user_maximum_days_between_password_change, 'foo') do
+  it { should eq "passwd -s foo | sed 's/ \\{1,\\}/%/g' | tr '%' '\n' | sed '5q;d'" }
+end


### PR DESCRIPTION
The output of chage on SLES 11 is different to other versions of SLES.
Additionally, Solaris 11 is not installed with chage so I have used
passwd to return the needed information.