### PR TITLE
Suppress Ruby warning

### DIFF
--- a/lib/specinfra/backend/base.rb
+++ b/lib/specinfra/backend/base.rb
@@ -14,6 +14,7 @@ module Specinfra
 
       def initialize(config = {})
         @config = config
+        @example = nil
       end
 
       def get_config(key)


### PR DESCRIPTION
Specinfra displays a warning on each command execution via SSH if `-w`
option is specified.

```
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/specinfra-2.77.1/lib/specinfra/backend/ssh.rb:24: warning: instance variable @example not initialized
```

This change will suppress the warnings.