### PR TITLE
Implemented check_is_installed_by_pip2

### DIFF
--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -44,7 +44,7 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
 
     def check_is_installed_by_pip2(name, version=nil)
       regexp = "^#{name}"
-      cmd = "pip list | grep -iw -- #{escape(regexp)}"
+      cmd = "pip2 list | grep -iw -- #{escape(regexp)}"
       cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
       cmd
     end

--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -41,6 +41,13 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
       cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
       cmd
     end
+
+    def check_is_installed_by_pip2(name, version=nil)
+      regexp = "^#{name}"
+      cmd = "pip list | grep -iw -- #{escape(regexp)}"
+      cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
+      cmd
+    end
     
     def check_is_installed_by_pip3(name, version=nil)
       regexp = "^#{name} "


### PR DESCRIPTION
I want to use pip2 command with serverspec.
Specinfra has `check_is_installed_by_pip()` and `check_is_installed_by_pip3()`, but not `check_is_installed_by_pip2()`.

So I implemented `check_is_installed_by_pip2()`.

Please consider my proposal.