### PR TITLE
Change exit status to a numeric comapre.

### DIFF
--- a/lib/specinfra/host_inventory/facter.rb
+++ b/lib/specinfra/host_inventory/facter.rb
@@ -10,7 +10,7 @@ module Specinfra
           nil
         end
 
-        ret.exit_status.zero? ? YAML.load(ret.stdout) : nil
+        ret.exit_status == 0 ? YAML.load(ret.stdout) : nil
       end
     end
   end


### PR DESCRIPTION
I'm still new to serverspec. On Windows hosts using the cmd backend I've had difficulty using the facter property of host_inventory. In debugging it seems that the .zero? method doesn't exist on the exit_status. Looking through specinfra for other compares for exit_status, it seems everything else is numeric. Changing this to a numeric compare fixed my issue locally.