### PR TITLE
Handle nil @example in cmd backend.

### DIFF
--- a/lib/specinfra/backend/cmd.rb
+++ b/lib/specinfra/backend/cmd.rb
@@ -49,7 +49,7 @@ module Specinfra
       private
 
       def powershell
-        architecture = @example.metadata[:architecture] || get_config(:architecture)
+         architecture = (@example.nil? ? nil : @example.metadata[:architecture]) || get_config(:architecture)
 
         case architecture
         when :i386 then x86_powershell

--- a/lib/specinfra/backend/cmd.rb
+++ b/lib/specinfra/backend/cmd.rb
@@ -49,7 +49,10 @@ module Specinfra
       private
 
       def powershell
-         architecture = (@example.nil? ? nil : @example.metadata[:architecture]) || get_config(:architecture)
+        architecture = if @example
+          @example.metadata[:architecture]
+        end
+        architecture ||= get_config(:architecture)
 
         case architecture
         when :i386 then x86_powershell


### PR DESCRIPTION
In the calling method run_command, it's possible @example is nil and is even checked for later in the method. A nil check is needed in the powershell method to handle cases where something like host_inventory is used outside of an example.