### PR TITLE
rhel8 support

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -96,6 +96,12 @@ require 'specinfra/command/redhat/v7/host'
 require 'specinfra/command/redhat/v7/service'
 require 'specinfra/command/redhat/v7/port'
 
+# RedHat V8 (inherit RedHat)
+require 'specinfra/command/redhat/v8'
+require 'specinfra/command/redhat/v8/host'
+require 'specinfra/command/redhat/v8/service'
+require 'specinfra/command/redhat/v8/port'
+
 # Fedora (inherit RedhHat)
 require 'specinfra/command/fedora'
 require 'specinfra/command/fedora/base'

--- a/lib/specinfra/command/redhat/v8.rb
+++ b/lib/specinfra/command/redhat/v8.rb
@@ -1,0 +1,3 @@
+class Specinfra::Command::Redhat::V8 < Specinfra::Command::Redhat::Base
+end
+

--- a/lib/specinfra/command/redhat/v8/host.rb
+++ b/lib/specinfra/command/redhat/v8/host.rb
@@ -1,0 +1,15 @@
+class Specinfra::Command::Redhat::V8::Host < Specinfra::Command::Redhat::Base::Host
+  class << self
+    def check_is_reachable(host, port, proto, timeout)
+      if port.nil?
+        "ping -w #{escape(timeout)} -c 2 -n #{escape(host)}"
+      else
+        # RHEL7 comes with ncat which does no longer sport the -z option
+        # hence this kludge
+        "ncat -vvvv#{escape(proto[0].chr)} #{escape(host)} #{escape(port)} " +
+        "-w #{escape(timeout)} -i #{escape(timeout)} 2>&1 | " +
+        "grep -q SUCCESS"
+      end
+    end
+  end
+end

--- a/lib/specinfra/command/redhat/v8/port.rb
+++ b/lib/specinfra/command/redhat/v8/port.rb
@@ -1,0 +1,5 @@
+class Specinfra::Command::Redhat::V8::Port < Specinfra::Command::Redhat::Base::Port
+  class << self
+    include Specinfra::Command::Module::Ss
+  end
+end

--- a/lib/specinfra/command/redhat/v8/service.rb
+++ b/lib/specinfra/command/redhat/v8/service.rb
@@ -1,0 +1,5 @@
+class Specinfra::Command::Redhat::V8::Service < Specinfra::Command::Redhat::Base::Service
+  class << self
+    include Specinfra::Command::Module::Systemd
+  end
+end


### PR DESCRIPTION
Support for RedHat 8.

I noticed that the service commands were failing when i moved from rhel7 to rhel8.  By copying the RHEL7 commands this seems to fulfil and work.

thanks

Nick