### PR TITLE
Implemented check_belongs_to_system_account

### DIFF
--- a/lib/specinfra/command/base/group.rb
+++ b/lib/specinfra/command/base/group.rb
@@ -8,6 +8,14 @@ class Specinfra::Command::Base::Group < Specinfra::Command::Base
       "getent group #{escape(group)} | cut -f 3 -d ':' | grep -w -- #{escape(gid)}"
     end
 
+    def check_belongs_to_system_account(group)
+      exists = "getent group #{escape(group)} > /dev/null 2>&1"
+      gid = "getent group #{escape(group)} | cut -f 3 -d ':'"
+      sys_gid_min = "awk 'BEGIN{sys_gid_min=101} {if($1~/^SYS_GID_MIN/){sys_gid_min=$2}} END{print sys_gid_min}' /etc/login.defs"
+      sys_gid_max = "awk 'BEGIN{sys_gid_max=0;gid_min=1000} {if($1~/^SYS_GID_MAX/){sys_gid_max=$2}if($1~/^GID_MIN/){gid_min=$2}} END{if(sys_gid_max!=0){print sys_gid_max}else{print gid_min-1}}' /etc/login.defs"
+      %Q|#{exists} && test "$(#{gid})" -ge "$(#{sys_gid_min})" && test "$(#{gid})" -le "$(#{sys_gid_max})"|
+    end
+
     def get_gid(group)
       "getent group #{escape(group)} | cut -f 3 -d ':'"
     end

--- a/lib/specinfra/command/base/group.rb
+++ b/lib/specinfra/command/base/group.rb
@@ -8,7 +8,7 @@ class Specinfra::Command::Base::Group < Specinfra::Command::Base
       "getent group #{escape(group)} | cut -f 3 -d ':' | grep -w -- #{escape(gid)}"
     end
 
-    def check_belongs_to_system_account(group)
+    def check_is_system_group(group)
       exists = "getent group #{escape(group)} > /dev/null 2>&1"
       gid = "getent group #{escape(group)} | cut -f 3 -d ':'"
       sys_gid_min = "awk 'BEGIN{sys_gid_min=101} {if($1~/^SYS_GID_MIN/){sys_gid_min=$2}} END{print sys_gid_min}' /etc/login.defs"

--- a/lib/specinfra/command/base/user.rb
+++ b/lib/specinfra/command/base/user.rb
@@ -12,7 +12,7 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
       "id -gn #{escape(user)}| grep ^#{escape(group)}$"
     end
 
-    def check_belongs_to_system_account(user)
+    def check_is_system_user(user)
       exists = "getent passwd #{escape(user)} > /dev/null 2>&1"
       uid = "getent passwd #{escape(user)} | cut -f 3 -d ':'"
       sys_uid_min = "awk 'BEGIN{sys_uid_min=101} {if($1~/^SYS_UID_MIN/){sys_uid_min=$2}} END{print sys_uid_min}' /etc/login.defs"

--- a/spec/command/base/group_spec.rb
+++ b/spec/command/base/group_spec.rb
@@ -17,3 +17,7 @@ end
 describe get_command(:add_group, 'foo', :system_group => true) do
   it { should eq 'groupadd -r foo' }
 end
+
+describe get_command(:check_group_belongs_to_system_account, 'foo') do
+  it { should eq "getent group foo > /dev/null 2>&1 && test \"$(getent group foo | cut -f 3 -d ':')\" -ge \"$(awk 'BEGIN{sys_gid_min=101} {if($1~/^SYS_GID_MIN/){sys_gid_min=$2}} END{print sys_gid_min}' /etc/login.defs)\" && test \"$(getent group foo | cut -f 3 -d ':')\" -le \"$(awk 'BEGIN{sys_gid_max=0;gid_min=1000} {if($1~/^SYS_GID_MAX/){sys_gid_max=$2}if($1~/^GID_MIN/){gid_min=$2}} END{if(sys_gid_max!=0){print sys_gid_max}else{print gid_min-1}}' /etc/login.defs)\"" }
+end

--- a/spec/command/base/group_spec.rb
+++ b/spec/command/base/group_spec.rb
@@ -18,6 +18,6 @@ describe get_command(:add_group, 'foo', :system_group => true) do
   it { should eq 'groupadd -r foo' }
 end
 
-describe get_command(:check_group_belongs_to_system_account, 'foo') do
+describe get_command(:check_group_is_system_group, 'foo') do
   it { should eq "getent group foo > /dev/null 2>&1 && test \"$(getent group foo | cut -f 3 -d ':')\" -ge \"$(awk 'BEGIN{sys_gid_min=101} {if($1~/^SYS_GID_MIN/){sys_gid_min=$2}} END{print sys_gid_min}' /etc/login.defs)\" && test \"$(getent group foo | cut -f 3 -d ':')\" -le \"$(awk 'BEGIN{sys_gid_max=0;gid_min=1000} {if($1~/^SYS_GID_MAX/){sys_gid_max=$2}if($1~/^GID_MIN/){gid_min=$2}} END{if(sys_gid_max!=0){print sys_gid_max}else{print gid_min-1}}' /etc/login.defs)\"" }
 end

--- a/spec/command/base/user_spec.rb
+++ b/spec/command/base/user_spec.rb
@@ -58,6 +58,6 @@ describe get_command(:update_user_login_shell, 'foo', '/bin/bash') do
   it { should eq 'usermod -s /bin/bash foo' }
 end
 
-describe get_command(:check_user_belongs_to_system_account, 'foo') do
+describe get_command(:check_user_is_system_user, 'foo') do
   it { should eq "getent passwd foo > /dev/null 2>&1 && test \"$(getent passwd foo | cut -f 3 -d ':')\" -ge \"$(awk 'BEGIN{sys_uid_min=101} {if($1~/^SYS_UID_MIN/){sys_uid_min=$2}} END{print sys_uid_min}' /etc/login.defs)\" && test \"$(getent passwd foo | cut -f 3 -d ':')\" -le \"$(awk 'BEGIN{sys_uid_max=0;uid_min=1000} {if($1~/^SYS_UID_MAX/){sys_uid_max=$2}if($1~/^UID_MIN/){uid_min=$2}} END{if(sys_uid_max!=0){print sys_uid_max}else{print uid_min-1}}' /etc/login.defs)\"" }
 end

--- a/spec/command/base/user_spec.rb
+++ b/spec/command/base/user_spec.rb
@@ -57,3 +57,7 @@ end
 describe get_command(:update_user_login_shell, 'foo', '/bin/bash') do
   it { should eq 'usermod -s /bin/bash foo' }
 end
+
+describe get_command(:check_user_belongs_to_system_account, 'foo') do
+  it { should eq "getent passwd foo > /dev/null 2>&1 && test \"$(getent passwd foo | cut -f 3 -d ':')\" -ge \"$(awk 'BEGIN{sys_uid_min=101} {if($1~/^SYS_UID_MIN/){sys_uid_min=$2}} END{print sys_uid_min}' /etc/login.defs)\" && test \"$(getent passwd foo | cut -f 3 -d ':')\" -le \"$(awk 'BEGIN{sys_uid_max=0;uid_min=1000} {if($1~/^SYS_UID_MAX/){sys_uid_max=$2}if($1~/^UID_MIN/){uid_min=$2}} END{if(sys_uid_max!=0){print sys_uid_max}else{print uid_min-1}}' /etc/login.defs)\"" }
+end


### PR DESCRIPTION
### Motivation

After adding with system_[user|group], I want to check whether it is a system account correctly.

#### SYS_UID_MIN, SYS_UID_MAX

```
The default value for SYS_UID_MIN (resp.  SYS_UID_MAX) is 101 (resp.  UID_MIN-1).
```

#### SYS_GID_MIN, SYS_GID_MAX

```
The default value for SYS_GID_MIN (resp.  SYS_GID_MAX) is 101 (resp.  GID_MIN-1).
```

### Appendix

See also: [login\.defs\(5\)](http://man7.org/linux/man-pages/man5/login.defs.5.html)