### PR TITLE
Wire in RHEL7 Service/Port/Host tests

### DIFF
--- a/lib/specinfra/command/redhat/base/host.rb
+++ b/lib/specinfra/command/redhat/base/host.rb
@@ -1,2 +1,11 @@
 class Specinfra::Command::Redhat::Base::Host < Specinfra::Command::Base::Host
+  class << self
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_i < 7
+        self
+      else
+        Specinfra::Command::Redhat::V7::Host
+      end
+    end
+  end
 end

--- a/lib/specinfra/command/redhat/base/port.rb
+++ b/lib/specinfra/command/redhat/base/port.rb
@@ -1,2 +1,11 @@
 class Specinfra::Command::Redhat::Base::Port < Specinfra::Command::Base::Port
+  class << self
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_i < 7
+        self
+      else
+        Specinfra::Command::Redhat::V7::Port
+      end
+    end
+  end
 end

--- a/lib/specinfra/command/redhat/base/service.rb
+++ b/lib/specinfra/command/redhat/base/service.rb
@@ -1,2 +1,11 @@
 class Specinfra::Command::Redhat::Base::Service < Specinfra::Command::Linux::Base::Service
+  class << self
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_i < 7
+        self
+      else
+        Specinfra::Command::Redhat::V7::Service
+      end
+    end
+  end
 end


### PR DESCRIPTION
When running a command test on a RHEL8 host I noticed that it was still relying on chkconfig.