### PR TITLE
Fix issues for Ruby 2.7-dev

### DIFF
--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -43,8 +43,7 @@ module Specinfra
       end
 
       def method_missing(meth, val=nil)
-        key = meth.to_s
-        key.gsub!(/=$/, '')
+        key = meth.to_s.gsub(/=$/, '')
         ret = nil
         begin
           if ! val.nil?

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -18,7 +18,12 @@ describe Specinfra::Backend::Exec do
       end
 
       it 'should escape quotes' do
-        expect(Specinfra.backend.build_command(%Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\\"']?http://ppa.launchpad.net/gluster/glusterfs-3.7"})).to eq('/bin/sh -c find\ /etc/apt/\ -name\ \*.list\ \|\ xargs\ grep\ -o\ -E\ \"\^deb\ \+\[\\\\\"\\\'\]\?http://ppa.launchpad.net/gluster/glusterfs-3.7\"')
+        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
+          expect(Specinfra.backend.build_command(%Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\\"']?http://ppa.launchpad.net/gluster/glusterfs-3.7"})).to eq('/bin/sh -c find\ /etc/apt/\ -name\ \*.list\ \|\ xargs\ grep\ -o\ -E\ \"\^deb\ \+\[\\\\\"\\\'\]\?http://ppa.launchpad.net/gluster/glusterfs-3.7\"')
+        else
+          # Since Ruby 2.7, `+` is not escaped.
+          expect(Specinfra.backend.build_command(%Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\\"']?http://ppa.launchpad.net/gluster/glusterfs-3.7"})).to eq('/bin/sh -c find\ /etc/apt/\ -name\ \*.list\ \|\ xargs\ grep\ -o\ -E\ \"\^deb\ +\[\\\\\"\\\'\]\?http://ppa.launchpad.net/gluster/glusterfs-3.7\"')
+        end
       end
     end
 


### PR DESCRIPTION
Specinfra has two problems with Ruby 2.7-dev.
This pull request will fix the problems.


# FrozenError

First, Specinfra::Configuration raises an error with Ruby 2.7.
I found the following backtrace with Itamae.

```
FrozenError: can't modify frozen String: "error_on_missing_backend_type="
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/specinfra-2.78.0/lib/specinfra/configuration.rb:47:in `gsub!'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/specinfra-2.78.0/lib/specinfra/configuration.rb:47:in `method_missing'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.4/lib/itamae/backend.rb:6:in `<top (required)>'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.4/lib/itamae.rb:10:in `require'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.4/lib/itamae.rb:10:in `<top (required)>'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.4/lib/itamae/cli.rb:1:in `require'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.4/lib/itamae/cli.rb:1:in `<top (required)>'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.4/bin/itamae:3:in `require'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.4/bin/itamae:3:in `<top (required)>'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/bin/itamae:23:in `load'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/bin/itamae:23:in `<top (required)>'
```


The cause is https://github.com/ruby/ruby/pull/2437.
`Symbol#to_s` returns a frozen string since Ruby 2.7.

So I replaced `gsub!` with `gsub` to avoid the error.



# Shellwords does not escape `+`


The spec was still failing with Ruby 2.7 after fixing the FrozenError.

```
Failures:

  1) Specinfra::Backend::Exec#build_command with complex command should escape quotes
     Failure/Error: expect(Specinfra.backend.build_command(%Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\\"']?http://ppa.launchpad.net/gluster/glusterfs-3.7"})).to eq('/bin/sh -c find\ /etc/apt/\ -name\ \*.list\ \|\ xargs\ grep\ -o\ -E\ \"\^deb\ \+\[\\\\\"\\\'\]\?http://ppa.launchpad.net/gluster/glusterfs-3.7\"')
     
       expected: "/bin/sh -c find\\ /etc/apt/\\ -name\\ \\*.list\\ \\|\\ xargs\\ grep\\ -o\\ -E\\ \\\"\\^deb\\ \\+\\[\\\\\\\"\\'\\]\\?http://ppa.launchpad.net/gluster/glusterfs-3.7\\\""
            got: "/bin/sh -c find\\ /etc/apt/\\ -name\\ \\*.list\\ \\|\\ xargs\\ grep\\ -o\\ -E\\ \\\"\\^deb\\ +\\[\\\\\\\"\\'\\]\\?http://ppa.launchpad.net/gluster/glusterfs-3.7\\\""
     
       (compared using ==)
     # ./spec/backend/exec/build_command_spec.rb:21:in `block (4 levels) in <top (required)>'

Finished in 8.77 seconds (files took 0.3102 seconds to load)
524 examples, 1 failure

Failed examples:

rspec ./spec/backend/exec/build_command_spec.rb:20 # Specinfra::Backend::Exec#build_command with complex command should escape quotes
```

The cause is https://github.com/ruby/ruby/commit/43a16c98df392e726040f0331a3e09d00c53d513.
Ruby 2.7's Shellwords does not escape `+`. So there are different results between Ruby 2.7 and older.

I fixed it in ea6fbfa.