### PR TITLE
Rhel8 selinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ TODO: Write usage instructions here
 
 ## Maintenance policy of Serverspec/Specinfra
 
-* The person who found a bug should fix the bug by themselves.
+* The person who found a bug should fix the bug by themself.
 * If you find a bug and cannot fix it by yourself, send a pull request and attach test code to reproduce the bug, please.
-* The person who want a new feature should implement it by themselves.
+* The person who want a new feature should implement it by themself.
 * For above reasons, I accept pull requests only and disable issues.
 * If you'd like to discuss about a new feature before implement it, make an empty commit and send [a WIP pull request](http://ben.straub.cc/2015/04/02/wip-pull-request/). But It is better that the WIP PR has some code than an empty commit.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or install it yourself as:
   ```
   bundle exec rake
   ```
-  
+
 ## Usage
 
 TODO: Write usage instructions here
@@ -34,9 +34,9 @@ TODO: Write usage instructions here
 
 ## Maintenance policy of Serverspec/Specinfra
 
-* The person who found a bug should fix the bug by themself.
+* The person who found a bug should fix the bug by themselves.
 * If you find a bug and cannot fix it by yourself, send a pull request and attach test code to reproduce the bug, please.
-* The person who want a new feature should implement it by themself.
+* The person who want a new feature should implement it by themselves.
 * For above reasons, I accept pull requests only and disable issues.
 * If you'd like to discuss about a new feature before implement it, make an empty commit and send [a WIP pull request](http://ben.straub.cc/2015/04/02/wip-pull-request/). But It is better that the WIP PR has some code than an empty commit.
 

--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -84,7 +84,7 @@ require 'specinfra/command/redhat/base/host'
 require 'specinfra/command/redhat/base/iptables'
 require 'specinfra/command/redhat/base/package'
 require 'specinfra/command/redhat/base/port'
-require 'specinfra/command/redhat/selinux_module'
+require 'specinfra/command/redhat/base/selinux_module'
 require 'specinfra/command/redhat/base/service'
 require 'specinfra/command/redhat/base/yumrepo'
 

--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -84,6 +84,7 @@ require 'specinfra/command/redhat/base/host'
 require 'specinfra/command/redhat/base/iptables'
 require 'specinfra/command/redhat/base/package'
 require 'specinfra/command/redhat/base/port'
+require 'specinfra/command/redhat/selinux_module'
 require 'specinfra/command/redhat/base/service'
 require 'specinfra/command/redhat/base/yumrepo'
 
@@ -96,6 +97,10 @@ require 'specinfra/command/redhat/v7'
 require 'specinfra/command/redhat/v7/host'
 require 'specinfra/command/redhat/v7/service'
 require 'specinfra/command/redhat/v7/port'
+
+# RedHat V7 (inherit RedHat)
+require 'specinfra/command/redhat/v8'
+require 'specinfra/command/redhat/v8/selinux_module'
 
 # Fedora (inherit RedhHat)
 require 'specinfra/command/fedora'

--- a/lib/specinfra/command/redhat/base/selinux_module.rb
+++ b/lib/specinfra/command/redhat/base/selinux_module.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Redhat::Base::SelinuxModule < Specinfra::Command::Linux::Base::SelinuxModule
+end

--- a/lib/specinfra/command/redhat/v8.rb
+++ b/lib/specinfra/command/redhat/v8.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Redhat::V8 < Specinfra::Command::Redhat::Base
+end

--- a/lib/specinfra/command/redhat/v8/selinux_module.rb
+++ b/lib/specinfra/command/redhat/v8/selinux_module.rb
@@ -1,4 +1,4 @@
-class Specinfra::Command::Redhat::V8::SelinuxModule < Specinfra::Command::Linux::Base::SelinuxModule
+class Specinfra::Command::Redhat::V8::SelinuxModule < Specinfra::Command::Redhat::Base::SelinuxModule
   class << self
     def check_is_installed(name, version=nil)
       cmd =  "semodule -l | grep $'^#{escape(name)}'"

--- a/lib/specinfra/command/redhat/v8/selinux_module.rb
+++ b/lib/specinfra/command/redhat/v8/selinux_module.rb
@@ -1,0 +1,13 @@
+class Specinfra::Command::Redhat::V8::SelinuxModule < Specinfra::Command::Linux::Base::SelinuxModule
+  class << self
+    def check_is_installed(name, version=nil)
+      cmd =  "semodule -l | grep $'^#{escape(name)}'"
+      cmd
+    end
+
+    def check_is_enabled(name)
+      cmd =  "semodule -l | grep $'^#{escape(name)}'"
+      cmd
+    end
+  end
+end

--- a/lib/specinfra/version.rb
+++ b/lib/specinfra/version.rb
@@ -1,3 +1,3 @@
 module Specinfra
-  VERSION = "2.82.5"
+  VERSION = "2.82.4"
 end

--- a/lib/specinfra/version.rb
+++ b/lib/specinfra/version.rb
@@ -1,3 +1,3 @@
 module Specinfra
-  VERSION = "2.82.4"
+  VERSION = "2.82.5"
 end


### PR DESCRIPTION
The basic idea is here, but at the moment this doesn't work, I am not sure why, will continue to look into it. In the meantime if you know why, please let me know and I'll fix it.

selinux modules in RHEL 8 are no longer versioned, the output of semodule -l also no longer lists disabled modules if the module is in the list it is enabled, if it is not in the list, it is disabled.

-Erinn