### PR TITLE
Fix warning: `&' interpreted as argument prefix

### DIFF
--- a/lib/specinfra/backend/powershell/command.rb
+++ b/lib/specinfra/backend/powershell/command.rb
@@ -6,7 +6,7 @@ module Specinfra
         def initialize &block
           @import_functions = []
           @script = ""
-          instance_eval &block if block_given?
+          instance_eval(&block) if block_given?
         end
 
         def using *functions


### PR DESCRIPTION
`instance_eval &block` seems to always print the following warning:

```
.../lib/specinfra/backend/powershell/command.rb:9: warning: `&' interpreted as argument prefix
```

I'd like to remove the warning by this PR.