### PR TITLE
Fix a constant name inconsistent with its path

### DIFF
--- a/lib/specinfra/command/ubuntu/v18/port.rb
+++ b/lib/specinfra/command/ubuntu/v18/port.rb
@@ -1,4 +1,4 @@
-class Specinfra::Command::Ubuntu::Base::V18::Port < Specinfra::Command::Ubuntu::Base::Port
+class Specinfra::Command::Ubuntu::V18::Port < Specinfra::Command::Ubuntu::Base::Port
   class << self
     include Specinfra::Command::Module::Ss
   end


### PR DESCRIPTION
Comparing it with other classes, I think `lib/specinfra/command/ubuntu/v18/port.rb` should have `Specinfra::Command::Ubuntu::V18::Port` like its path, not including `::Base` inside it.