### PR TITLE
Modify yumrepo for RHEL 8 to work with chef

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or install it yourself as:
   ```
   bundle exec rake
   ```
-  
+
 ## Usage
 
 TODO: Write usage instructions here
@@ -34,9 +34,9 @@ TODO: Write usage instructions here
 
 ## Maintenance policy of Serverspec/Specinfra
 
-* The person who found a bug should fix the bug by themself.
+* The person who found a bug should fix the bug by themselves.
 * If you find a bug and cannot fix it by yourself, send a pull request and attach test code to reproduce the bug, please.
-* The person who want a new feature should implement it by themself.
+* The person who want a new feature should implement it by themselves.
 * For above reasons, I accept pull requests only and disable issues.
 * If you'd like to discuss about a new feature before implement it, make an empty commit and send [a WIP pull request](http://ben.straub.cc/2015/04/02/wip-pull-request/). But It is better that the WIP PR has some code than an empty commit.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or install it yourself as:
   ```
   bundle exec rake
   ```
-
+  
 ## Usage
 
 TODO: Write usage instructions here
@@ -34,9 +34,9 @@ TODO: Write usage instructions here
 
 ## Maintenance policy of Serverspec/Specinfra
 
-* The person who found a bug should fix the bug by themselves.
+* The person who found a bug should fix the bug by themself.
 * If you find a bug and cannot fix it by yourself, send a pull request and attach test code to reproduce the bug, please.
-* The person who want a new feature should implement it by themselves.
+* The person who want a new feature should implement it by themself.
 * For above reasons, I accept pull requests only and disable issues.
 * If you'd like to discuss about a new feature before implement it, make an empty commit and send [a WIP pull request](http://ben.straub.cc/2015/04/02/wip-pull-request/). But It is better that the WIP PR has some code than an empty commit.
 

--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -97,6 +97,10 @@ require 'specinfra/command/redhat/v7/host'
 require 'specinfra/command/redhat/v7/service'
 require 'specinfra/command/redhat/v7/port'
 
+# RedHat V8 (inherit RedHat)
+require 'specinfra/command/redhat/v8'
+require 'specinfra/command/redhat/v8/yumrepo'
+
 # Fedora (inherit RedhHat)
 require 'specinfra/command/fedora'
 require 'specinfra/command/fedora/base'

--- a/lib/specinfra/command/redhat/v8.rb
+++ b/lib/specinfra/command/redhat/v8.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Redhat::V8 < Specinfra::Command::Redhat::Base
+end

--- a/lib/specinfra/command/redhat/v8/yumrepo.rb
+++ b/lib/specinfra/command/redhat/v8/yumrepo.rb
@@ -1,0 +1,11 @@
+class Specinfra::Command::Redhat::V8::Yumrepo < Specinfra::Command::Redhat::Base::Yumrepo
+  class << self
+    def check_exists(repository)
+      "dnf repolist all | grep -qsE \"^[\\!\\*]?#{escape(repository)}\(\\s\|$\|\\/)\""
+    end
+
+    def check_is_enabled(repository)
+      "dnf repolist enabled | grep -qs \"^[\\!\\*]\\?#{escape(repository)}\""
+    end
+  end
+end


### PR DESCRIPTION
Because RHEL 8 links yum directly to DNF now the behavior of some things have changed slightly. This is a fix for the way chef handles creating repositories, the issue with chef is here:
https://github.com/chef/chef/blob/7558c414030d082194d0d2b5f74279ce151517e9/lib/chef/provider/yum_repository.rb#L54 chef cleans the metadata after creating a repository, the way yum (apparently) used to work is that it would only clean the yum metadata for the named repo and none of the others. DNF removes all of the metadata period.

This means that when serverspec attempts to do yumrepo calls on a RHEL 8 system it fails like so:
dnf repolist enabled -C
Updating Subscription Management repositories.
Cache-only enabled but no cache for 'epel'
Error: Cache-only enabled but no cache for 'epel'

Same for dnf repolist all -C 

By removing the requirement to go against the local cache and allowing dnf to update the cache if needed, it works. 