### PR TITLE
Relax openSUSE detection

### DIFF
--- a/lib/specinfra/helper/detect_os/suse.rb
+++ b/lib/specinfra/helper/detect_os/suse.rb
@@ -2,7 +2,7 @@ class Specinfra::Helper::DetectOs::Suse < Specinfra::Helper::DetectOs
   def detect
     if run_command('ls /etc/os-release').success? and run_command('zypper -V').success?
       line = run_command('cat /etc/os-release').stdout
-      if line =~ /ID=opensuse/
+      if line =~ /ID="?opensuse/
         family = 'opensuse'
       elsif line =~ /ID="sles"/
         family = 'sles'


### PR DESCRIPTION
I'm trying to use mitamae on this kind of openSUSE environment:

```
ec2-user@ip-172-31-3-159:~> cat /etc/os-release
NAME="openSUSE Leap"
VERSION="15.1"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="15.1"
PRETTY_NAME="openSUSE Leap 15.1"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:15.1"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
```

I need this patch to run mitamae on the server.