### PR TITLE
Support all OpenRC commands in Gentoo

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -14,9 +14,11 @@ require 'specinfra/command/module/service/runit'
 require 'specinfra/command/module/service/monit'
 require 'specinfra/command/module/service/god'
 require 'specinfra/command/module/service/delegator'
+require 'specinfra/command/module/service/openrc'
 require 'specinfra/command/module/systemd'
 require 'specinfra/command/module/zfs'
 require 'specinfra/command/module/ss'
+require 'specinfra/command/module/openrc'
 
 # Base
 require 'specinfra/command/base'

--- a/lib/specinfra/command/alpine/base/service.rb
+++ b/lib/specinfra/command/alpine/base/service.rb
@@ -1,31 +1,5 @@
 class Specinfra::Command::Alpine::Base::Service < Specinfra::Command::Linux::Base::Service
   class << self
-    def check_is_enabled(service, level=3)
-      "rc-update show boot default | grep -w #{escape(service)}"
-    end
-
-    def check_is_running(service)
-      "/etc/init.d/#{escape(service)} status"
-    end
-
-    def enable(service)
-      "rc-update add #{escape(service)}"
-    end
-
-    def disable(service)
-      "rc-update del #{escape(service)}"
-    end
-
-    def start(service)
-      "rc-service #{escape(service)} start"
-    end
-
-    def stop(service)
-      "rc-service #{escape(service)} stop"
-    end
-
-    def restart(service)
-      "rc-service #{escape(service)} restart"
-    end
+    include Specinfra::Command::Module::OpenRC
   end
 end

--- a/lib/specinfra/command/gentoo/base/service.rb
+++ b/lib/specinfra/command/gentoo/base/service.rb
@@ -1,13 +1,6 @@
 class Specinfra::Command::Gentoo::Base::Service < Specinfra::Command::Linux::Base::Service
   class << self
-    def check_is_enabled(service, level=3)
-      regexp = /\s*#{service}\s*\|\s*(boot|default)/
-      "rc-update show | grep -- #{escape(regexp)}"
-    end
-
-    def check_is_running(service)
-      "/etc/init.d/#{escape(service)} status"
-    end
+    include Specinfra::Command::Module::OpenRC
   end
 end
 

--- a/lib/specinfra/command/module/openrc.rb
+++ b/lib/specinfra/command/module/openrc.rb
@@ -1,0 +1,11 @@
+module Specinfra
+  module Command
+    module Module
+      module OpenRC
+        include Specinfra::Command::Module::Service::OpenRC
+        extend  Specinfra::Command::Module::Service::Delegator
+        def_delegator_service_under :openrc
+      end
+    end
+  end
+end

--- a/lib/specinfra/command/module/service/openrc.rb
+++ b/lib/specinfra/command/module/service/openrc.rb
@@ -1,0 +1,41 @@
+module Specinfra
+  module Command
+    module Module
+      module Service
+        module OpenRC
+          def check_is_enabled_under_openrc(service, level=3)
+            "rc-update show boot default | grep -w #{escape(service)}"
+          end
+
+          def check_is_running_under_openrc(service)
+            "/etc/init.d/#{escape(service)} status"
+          end
+
+          def enable_under_openrc(service)
+            "rc-update add #{escape(service)}"
+          end
+
+          def disable_under_openrc(service)
+            "rc-update del #{escape(service)}"
+          end
+
+          def start_under_openrc(service)
+            "rc-service #{escape(service)} start"
+          end
+
+          def stop_under_openrc(service)
+            "rc-service #{escape(service)} stop"
+          end
+
+          def restart_under_openrc(service)
+            "rc-service #{escape(service)} restart"
+          end
+
+          def reload_under_openrc(service)
+            "/etc/init.d/#{escape(service)} reload"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
mitamae's `service` resource didn't work on a Gentoo machine because many OpenRC commands are missing in `Specinfra::Command::Gentoo::Base::Service`.

To make sure OpenRC commands are used on Gentoo, I shared OpenRC service commands between Alpine and Gentoo, and added reload implementation to it.