### PR TITLE
fix: use nc -G option for timeout

### DIFF
--- a/lib/specinfra/command/darwin/base/host.rb
+++ b/lib/specinfra/command/darwin/base/host.rb
@@ -16,7 +16,7 @@ class Specinfra::Command::Darwin::Base::Host < Specinfra::Command::Base::Host
       if port.nil?
         "ping -t #{escape(timeout)} -c 2 -n #{escape(host)}"
       else
-        "nc -vvvvz#{escape(proto[0].chr)} #{escape(host)} #{escape(port)} -w #{escape(timeout)}"
+        "nc -vvvvz#{escape(proto[0].chr)} #{escape(host)} #{escape(port)} -w #{escape(timeout)} -G #{escape(timeout)}"
       end
     end
 

--- a/spec/command/darwin/host_spec.rb
+++ b/spec/command/darwin/host_spec.rb
@@ -19,8 +19,8 @@ describe get_command(:check_host_is_reachable, 'pink.unicorn.com', nil, 'tcp', 1
   it { should eq "ping -t 10 -c 2 -n pink.unicorn.com"} 
 end
 
-describe get_command(:check_host_is_reachable, 'pink.unicorn.com', 53, 'udp', 66) do 
-  it { should eq "nc -vvvvzu pink.unicorn.com 53 -w 66" } 
+describe get_command(:check_host_is_reachable, 'pink.unicorn.com', 53, 'udp', 66) do
+  it { should eq "nc -vvvvzu pink.unicorn.com 53 -w 66 -G 66" }
 end
 
 describe get_command(:get_host_ipaddress, 'pink.unicorn.com') do 


### PR DESCRIPTION
The netcat implementation on Darwin has the -G option setting the tcp
connection timeout, whereas the -w option sets the STDIN idle timeout.