### PR TITLE
Fix user.rb for non-unique uids

### DIFF
--- a/lib/specinfra/command/base/user.rb
+++ b/lib/specinfra/command/base/user.rb
@@ -1,15 +1,17 @@
 class Specinfra::Command::Base::User < Specinfra::Command::Base
   class << self
     def check_exists(user)
-      "id #{escape(user)}"
+      "getent passwd #{escape(user)}"
     end
 
     def check_belongs_to_group(user, group)
-      "id #{escape(user)} | sed 's/ context=.*//g' | cut -f 4 -d '=' | grep -- #{escape(group)}"
+      "getent group #{escape(group)} | grep -- #{escape(user)}"
     end
 
     def check_belongs_to_primary_group(user, group)
-      "id -gn #{escape(user)}| grep ^#{escape(group)}$"
+      pgid = "getent passwd #{escape(user)} | cut -f 4 -d ':'"
+      ggid = "getent group #{escape(group)} | cut -f 3 -d ':'"
+      %Q|test "#{escape(pgid)}" -eq "#{escape(ggid)}"|
     end
 
     def check_is_system_user(user)
@@ -21,8 +23,8 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
     end
 
     def check_has_uid(user, uid)
-      regexp = "^uid=#{uid}("
-      "id #{escape(user)} | grep -- #{escape(regexp)}"
+      auid = "getent passwd #{escape(user)} | cut -f 3 -d ':'"
+      %Q| test "#{escape(uid)}" -eq "#{escape(auid)}"|
     end
 
     def check_has_home_directory(user, path_to_home)
@@ -47,11 +49,11 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
     end
 
     def get_uid(user)
-      "id -u #{escape(user)}"
+      "getent passwd #{escape(user)} | cut -f 3 -d ':'"
     end
 
     def get_gid(user)
-      "id -g #{escape(user)}"
+      "getent passwd #{escape(user)} | cut -f 4 -d ':'"
     end
 
     def get_home_directory(user)

--- a/lib/specinfra/command/base/user.rb
+++ b/lib/specinfra/command/base/user.rb
@@ -5,7 +5,7 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
     end
 
     def check_belongs_to_group(user, group)
-      "getent group #{escape(group)} | grep -- #{escape(user)}"
+      "groups #{escape(user)} | grep -- #{escape(group)}"
     end
 
     def check_belongs_to_primary_group(user, group)


### PR DESCRIPTION
`id` outputs the first uid that matches when presented with potentially multiple users with the same uid. This means that if 2 users with the same uid are present all of the calls to `id` may return the incorrect user. `getent` has this same property when looking up users by `uid` but this doesn't happen when looking them up using their name.