### PR TITLE
Ensure the matched port is listening

### DIFF
--- a/lib/specinfra/backend/powershell/support/is_port_listening.ps1
+++ b/lib/specinfra/backend/powershell/support/is_port_listening.ps1
@@ -5,9 +5,10 @@ function IsPortListening
   $networkIPs = (Get-WmiObject Win32_NetworkAdapterConfiguration | ? {$_.IPEnabled}) | %{ $_.IPAddress[0] }
   [array] $networkIPs += "0.0.0.0"
   [array] $networkIPs += "127.0.0.1"
+  [array] $networkIPs += "[::1]"
   foreach ($ipaddress in $networkIPs)
   {
-    $matchExpression = ("$ipaddress" + ":" + $portNumber)
+    $matchExpression = ("$ipaddress" + ":" + $portNumber + ".*LISTENING")
     if ($protocol) { $matchExpression = ($protocol.toUpper() + "\s+$matchExpression") }
     if ($netstatOutput -match $matchExpression) { return $true }
   }


### PR DESCRIPTION
This change avoids matching against a port that is in TIME_WAIT or other non-listening states

Also, allow matching on ipv6 local

 