### PR TITLE
Remove strict_host_key_checking option when net-ssh does not support it

### DIFF
--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -73,10 +73,16 @@ module Specinfra
       end
 
       def create_ssh
+        options = get_config(:ssh_options)
+
+        if !Net::SSH::VALID_OPTIONS.include?(:strict_host_key_checking)
+          options.delete(:strict_host_key_checking)
+        end
+
         Net::SSH.start(
           get_config(:host),
-          get_config(:ssh_options)[:user],
-          get_config(:ssh_options)
+          options[:user],
+          options
         )
       end
 


### PR DESCRIPTION
net-ssh 6.0 seems not to support this options like this error:

```
net-ssh-6.0.2/lib/net/ssh.rb:221:in `start': invalid option(s):
strict_host_key_checking (ArgumentError)
```