### PR TITLE
Add get_size(file) for darwin

### DIFF
--- a/lib/specinfra/command/darwin/base/file.rb
+++ b/lib/specinfra/command/darwin/base/file.rb
@@ -34,6 +34,10 @@ class Specinfra::Command::Darwin::Base::File < Specinfra::Command::Base::File
     def get_mode(file)
       "stat -f%Lp #{escape(file)}"
     end
+    
+    def get_size(file)
+      "stat -f %z #{escape(file)}"
+    end
 
     def get_owner_user(file)
       "stat -f %Su #{escape(file)}"


### PR DESCRIPTION
The default file size command, `stat -c`, does not work on macOS:

```
$ stat -c /Users/Shared
stat: illegal option -- c
usage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]
```

This PR adds a `get_size()` method for darwin that uses `stat -f %z` (same command as free/openbsd).

**Test:**

```ruby
describe file("/Users/Shared") do
  its(:size) { should > 10 }
end
```

**Before:**

```ruby
$ rspec

File "/Users/Shared"
  size
    is expected to > 10 (FAILED - 1)

Failures:

  1) File "/Users/Shared" size is expected to > 10
     Failure/Error: its(:size) { should > 10 }
       expected: > 10
            got:   0
       /bin/sh -c stat\ -c\ \%s\ /Users/Shared
       
     # ./spec/localhost/sample_spec.rb:4:in `block (2 levels) in <top (required)>'

Finished in 0.19662 seconds (files took 0.90007 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/localhost/sample_spec.rb:4 # File "/Users/Shared" size is expected to > 10
```

**After:**

```ruby
$ rspec

File "/Users/Shared"
  size
    is expected to > 10

Finished in 0.17988 seconds (files took 0.87242 seconds to load)
1 example, 0 failures
```

**OS version:**

```bash
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.15.6
BuildVersion:   19G46c
```
