### PR TITLE
Detect UEFI VMware guests

### DIFF
--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -32,7 +32,7 @@ module Specinfra
 
       def parse_system_product_name(ret)
         product_name = case ret
-          when /.*VMware Virtual Platform/
+          when /.*(VMware Virtual Platform|VMware7,1)/
             'vmware'
           when /.*VirtualBox/
             'vbox'


### PR DESCRIPTION
A VMware guest booted with UEFI will report 'VMWare7,1' in the DMI product
name but parse_system_product_name() only looks for 'VMware Virtual Platform'
which is what it reports when booted with legacy BIOS.