### PR TITLE
Windows: support check_is_installed_by_gem

### DIFF
--- a/lib/specinfra/backend/powershell/support/find_installed_gem.ps1
+++ b/lib/specinfra/backend/powershell/support/find_installed_gem.ps1
@@ -1,0 +1,20 @@
+function FindInstalledGem
+{
+  param($gemName, $gemVersion)
+
+  $nameVer = $(Invoke-Expression "gem list --local" | Select-String "$gemName").Line
+  if ($nameVer.StartsWith($gemName)) {
+    if ($gemVersion) {
+      if ($nameVer.EndsWith("$gemVersion)")) {
+        $true
+      } else {
+        $false
+      }
+    } else {
+      $true
+    }
+  } else {
+    $false
+  }
+}
+

--- a/lib/specinfra/command/windows/base/package.rb
+++ b/lib/specinfra/command/windows/base/package.rb
@@ -7,5 +7,13 @@ class Specinfra::Command::Windows::Base::Package < Specinfra::Command::Windows::
         exec "(FindInstalledApplication -appName '#{package}' #{version_selection}) -eq $true"
       end
     end
+
+    def check_is_installed_by_gem(name, version=nil, gem_binary="gem")
+      version_selection = version.nil? ? "" : "-gemVersion '#{version}'"
+      Backend::PowerShell::Command.new do
+        using 'find_installed_gem.ps1'
+        exec "(FindInstalledGem -gemName '#{name}' #{version_selection}) -eq $true"
+      end
+    end
   end
 end


### PR DESCRIPTION
Example:

  describe package("#{spec.name}") do
    it { should be_installed.by("gem").with_version(spec.version) }
  end

This commit fixes the following error:

  check_is_installed_by_gem is not implemented in Specinfra::Command::Windows::Base::Package