### PR TITLE
Windows: fix wrong gem version detection

### DIFF
--- a/lib/specinfra/backend/powershell/support/find_installed_gem.ps1
+++ b/lib/specinfra/backend/powershell/support/find_installed_gem.ps1
@@ -2,7 +2,7 @@ function FindInstalledGem
 {
   param($gemName, $gemVersion)
 
-  $nameVer = $(Invoke-Expression "gem list --local" | Select-String "$gemName").Line
+  $nameVer = $(Invoke-Expression "gem list --local" | Select-String "^$gemName").Line
   if ($nameVer.StartsWith($gemName)) {
     if ($gemVersion) {
       $versions = ($nameVer -split { $_ -eq "(" -or $_ -eq ")"})[1].split(" ")

--- a/lib/specinfra/backend/powershell/support/find_installed_gem.ps1
+++ b/lib/specinfra/backend/powershell/support/find_installed_gem.ps1
@@ -5,7 +5,8 @@ function FindInstalledGem
   $nameVer = $(Invoke-Expression "gem list --local" | Select-String "$gemName").Line
   if ($nameVer.StartsWith($gemName)) {
     if ($gemVersion) {
-      if ($nameVer.EndsWith("$gemVersion)")) {
+      $versions = ($nameVer -split { $_ -eq "(" -or $_ -eq ")"})[1].split(" ")
+      if ($versions.Contains($gemVersion)) {
         $true
       } else {
         $false


### PR DESCRIPTION
In the previous version, foobar (x.y.z x64-mingw32)
is not detected correctly.