### PR TITLE
ss: fix local_address format for IPv6.

### DIFF
--- a/lib/specinfra/command/module/ss.rb
+++ b/lib/specinfra/command/module/ss.rb
@@ -22,7 +22,15 @@ module Specinfra
           if local_address == '0.0.0.0'
             [ '\*' , '0\.0\.0\.0' ]
           else
-            [ local_address ]
+            [ fix_format_if_ipv6(local_address) ]
+          end
+        end
+
+        def fix_format_if_ipv6(local_address)
+          if local_address =~ /.*:.*/
+            "\\[#{local_address}\\]"
+          else
+            local_address
           end
         end
 

--- a/spec/command/module/ss_spec.rb
+++ b/spec/command/module/ss_spec.rb
@@ -14,15 +14,15 @@ describe Specinfra::Command::Module::Ss do
 
   it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0'})).to eq 'ss -tunl | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '::', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -E -- \ \\\\\\[::\\\\\\]:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp'})).to eq 'ss -unl4 | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '0.0.0.0', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -E -- \ \\\\\*:80\ \\|\\ 0\\\\.0\\\\.0\\\\.0:80\\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '::', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -E -- \ \\\\\\[::\\\\\\]:80\ ' }
 
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4'})).to eq 'ss -tunl | grep -E -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -E -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -E -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'tcp'})).to eq 'ss -tnl4 | grep -E -- \\ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '2001:db8:dead:beef::1', :protocol => 'tcp6'})).to eq 'ss -tnl6 | grep -E -- \ \\\\\\[2001:db8:dead:beef::1\\\\\\]:80\ ' }
   it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp'})).to eq 'ss -unl4 | grep -E -- \ 1.2.3.4:80\ ' }
-  it { expect(klass.check_is_listening('80', options={:local_address => '1.2.3.4', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -E -- \ 1.2.3.4:80\ ' }
+  it { expect(klass.check_is_listening('80', options={:local_address => '2001:db8:dead:beef::1', :protocol => 'udp6'})).to eq 'ss -unl6 | grep -E -- \ \\\\\\[2001:db8:dead:beef::1\\\\\\]:80\ ' }
 
   it { expect{klass.check_is_listening('80', options={:protocol => 'bad_proto'})}.to raise_error(ArgumentError, 'Unknown protocol [bad_proto]') }
 end


### PR DESCRIPTION
- make sure tests have IPv6 format instead IPv4
- fix local_address format when addresses are IPv6 (i.e. contain
  at least one colon): ss reports those addresses between brackets