### PR TITLE
Add: Services check for Homebrew

### DIFF
--- a/lib/specinfra/command/darwin/base/service.rb
+++ b/lib/specinfra/command/darwin/base/service.rb
@@ -4,8 +4,16 @@ class Specinfra::Command::Darwin::Base::Service < Specinfra::Command::Base::Serv
       "launchctl list | grep #{escape(service)}"
     end
 
+    def check_is_enabled_under_homebrew(service)
+      "brew services list | grep #{escape(service)}"
+    end
+
     def check_is_running(service)
       "launchctl list | grep #{escape(service)} | grep -E '^[0-9]+'"
+    end
+
+    def check_is_running_under_homebrew(service)
+      "brew services list | grep #{escape(service)} | grep 'started'"
     end
   end
 end


### PR DESCRIPTION
[Homebrew](https://github.com/Homebrew/homebrew-services) now supports services.

I still haven't add any tests because I wasn't exactly sure if I was supposed to create a `service_spec.rb` for it or if `darwin` should be a submodule like `Specinfra::Command::Module::Service::Systemd`

I know Homebrew is now supported on other systems so I guess maybe a module?  But i'm less clear how to do that correctly.