### PR TITLE
update is_port_listening.ps1

### DIFF
--- a/lib/specinfra/backend/powershell/support/is_port_listening.ps1
+++ b/lib/specinfra/backend/powershell/support/is_port_listening.ps1
@@ -6,9 +6,10 @@ function IsPortListening
   [array] $networkIPs += "0.0.0.0"
   [array] $networkIPs += "127.0.0.1"
   [array] $networkIPs += "[::1]"
+  [array] $networkIPs += "[::]"
   foreach ($ipaddress in $networkIPs)
   {
-    $matchExpression = ("$ipaddress" + ":" + $portNumber + ".*LISTENING")
+    $matchExpression = ("$ipaddress" + ":" + $portNumber + ".*(LISTENING|\*:\*)")
     if ($protocol) { $matchExpression = ($protocol.toUpper() + "\s+$matchExpression") }
     if ($netstatOutput -match $matchExpression) { return $true }
   }


### PR DESCRIPTION
Update the is_port_listening.ps1 powershell script to include the ipv6 equivalent of 0.0.0.0 ([::]) when checking for listening ports.

Update matcher to match on "LISTENING" or "*:*" in the netstat output, as listening UDP ports do not have a "state" and only list the foreign address of "*:*" in the netstat output