### PR TITLE
windows: fix version detection when multiple gem is installed

### DIFF
--- a/lib/specinfra/backend/powershell/support/find_installed_gem.ps1
+++ b/lib/specinfra/backend/powershell/support/find_installed_gem.ps1
@@ -5,7 +5,7 @@ function FindInstalledGem
   $nameVer = $(Invoke-Expression "gem list --local" | Select-String "^$gemName").Line
   if ($nameVer.StartsWith($gemName)) {
     if ($gemVersion) {
-      $versions = ($nameVer -split { $_ -eq "(" -or $_ -eq ")"})[1].split(" ")
+      $versions = ($nameVer -split { $_ -eq "(" -or $_ -eq ")"})[1].split(", ")
       if ($versions.Contains($gemVersion)) {
         $true
       } else {


### PR DESCRIPTION
In the previous version, installed multiple version is not
handled correctly, so only last version is detected correctly.

Before:
 If rake (13.0.3, 13.0.1) then, FindInstalledGem("rake", "13.0.3")
 returns False because ["13.0.3,", "13.0.1"].Contains("13.0.3") is
 checked.

After:
 If rake (13.0.3, 13.0.1) then, FindInstalledGem("rake", "13.0.3")
 returns True because ["13.0.3", "13.0.1"].Contains("13.0.3") is
 checked.