### PR TITLE
debian: add support for Debian testing and unstable

### DIFF
--- a/lib/specinfra/command/debian/base/port.rb
+++ b/lib/specinfra/command/debian/base/port.rb
@@ -1,10 +1,11 @@
 class Specinfra::Command::Debian::Base::Port < Specinfra::Command::Linux::Base::Port
   class << self
     def create(os_info=nil)
-      if (os_info || os)[:release].to_i < 8
-        self
-      else
+      release = (os_info || os)[:release]
+      if ["testing", "unstable"].include?(release) || release.to_i >= 8
         Specinfra::Command::Debian::V8::Port
+      else
+        self
       end
     end
   end

--- a/lib/specinfra/command/debian/base/service.rb
+++ b/lib/specinfra/command/debian/base/service.rb
@@ -1,10 +1,11 @@
 class Specinfra::Command::Debian::Base::Service < Specinfra::Command::Linux::Base::Service
   class << self
     def create(os_info=nil)
-      if (os_info || os)[:release].to_i < 8
-        self
-      else
+      release = (os_info || os)[:release]
+      if ["testing", "unstable"].include?(release) || release.to_i >= 8
         Specinfra::Command::Debian::V8::Service
+      else
+        self
       end
     end
 

--- a/spec/command/debiantesting/port_spec.rb
+++ b/spec/command/debiantesting/port_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'debian', :release => 'testing'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq 'ss -tunl | grep -E -- :80\ ' }
+end

--- a/spec/command/debiantesting/service_spec.rb
+++ b/spec/command/debiantesting/service_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'debian', :release => 'testing'
+
+describe get_command(:check_service_is_enabled, 'apache') do
+  it { should eq 'systemctl --quiet is-enabled apache||ls /etc/rc[S5].d/S??apache >/dev/null 2>/dev/null' }
+end

--- a/spec/command/debianunstable/port_spec.rb
+++ b/spec/command/debianunstable/port_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'debian', :release => 'unstable'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq 'ss -tunl | grep -E -- :80\ ' }
+end

--- a/spec/command/debianunstable/service_spec.rb
+++ b/spec/command/debianunstable/service_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'debian', :release => 'unstable'
+
+describe get_command(:check_service_is_enabled, 'apache') do
+  it { should eq 'systemctl --quiet is-enabled apache||ls /etc/rc[S5].d/S??apache >/dev/null 2>/dev/null' }
+end


### PR DESCRIPTION
This allows proper service and port management of hosts using unreleased
versions of Debian, which were being identified as pre-v8 and thus not
using systemd/ss properly.