### PR TITLE
use localcert for older rubies on appvayor test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,7 @@ install:
   - ps: $PSVersionTable
 
 build_script:
+  - set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
   - ruby -rfileutils -e 'FileUtils.rm_r(File.join(Gem.dir, "cache", "bundler")) if Dir.exists?(File.join(Gem.dir, "cache", "bundler"))'
   - bundle install --jobs 3 --retry 3
   - net user


### PR DESCRIPTION
I found a solution to the error about the certificate in the official documentation.

https://www.appveyor.com/docs/lang/ruby/#openssl-verification

`Use set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem`