### PR TITLE
Resolve namespace properly for File

### DIFF
--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Package
   class << self
     def check_is_installed(package, version=nil)
-      escaped_package = escape(File.basename(package))
+      escaped_package = escape(::File.basename(package))
       if version
         cmd = %Q[brew info #{escaped_package} | grep -E "^$(brew --prefix)/Cellar/#{escaped_package}/#{escape(version)}"]
       else
@@ -13,7 +13,7 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     alias :check_is_installed_by_homebrew :check_is_installed
 
     def check_is_installed_by_homebrew_cask(package, version=nil)
-      escaped_package = escape(File.basename(package))
+      escaped_package = escape(::File.basename(package))
       if version
         cmd = "brew cask info #{escaped_package} | grep -E '^/opt/homebrew-cask/Caskroom/#{escaped_package}/#{escape(version)}'"
       else


### PR DESCRIPTION
resolves NoMethodError: NoMethodError: undefined method 'basename' for
Specinfra::Command::Darwin::Base::File in darwin environment.

## Background

Since upgrading mitamae >= v1.12.2 (includes upgrading mruby from v2.1.2 to v3.0.0), I've been getting the following error with package resource in darwin environment:

```bash
$ ./mitamae-aarch64-darwin version
mitamae v1.12.3

$ cat recipe.rb
package 'git'

$ ./mitamae-aarch64-darwin local recipe.rb --log-level=debug
 INFO : Starting mitamae...
DEBUG : Loading recipe: recipe.rb
 INFO : Recipe: /Users/rrreeeyyy/sandbox/mitamae/recipe.rb
DEBUG :   package[git]
DEBUG :     package[git] action: install
DEBUG :       (in set_desired_attributes)
DEBUG :       (in set_current_attributes)
undefined method 'basename' (NoMethodError)
```

This error is due to the File class being resolved as Specinfra::Command::Base::File in Specinfra::Command::Darwin::Base::Package on mruby-specinfra.

```ruby
$ cat class.rb
local_ruby_block 'Specinfra::Command::Darwin::Base::Package file class' do
  block do
    class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Package
      def file_class
        p File
      end
    end

    Specinfra::Command::Darwin::Base::Package.new.file_class
  end
end
```

```bash
$ ./mitamae-aarch64-darwin local class.rb
 INFO : Starting mitamae...
 INFO : Recipe: /Users/rrreeeyyy/tmp/mitamae/class.rb
 INFO :   local_ruby_block[Specinfra::Command::Darwin::Base::Package file class] executed will change from 'false' to 'true'
Specinfra::Command::Base::File
```

This patch changes namespace resolution for File class to avoid errors in the mruby environment.
This change should have no impact on other Ruby environments.