### PR TITLE
Drop EoL rubies / add latest rubies to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: trusty
+dist: focal
 
 rvm:
   - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,6 @@ language: ruby
 dist: trusty
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
   - 2.6
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ dist: trusty
 
 rvm:
   - 2.6
+  - 2.7
+  - 3.0
 
 before_install:
-  - travis_retry gem update --system 2.7.8
-  - travis_retry gem install bundler -v 1.17.3
-  - travis_retry gem uninstall -i /home/travis/.rvm/gems/ruby-2.3.7@global bundler || echo
+  - travis_retry gem update --system
+  - travis_retry gem install bundler
 
 script:
   - bundle exec rake spec
@@ -17,5 +18,3 @@ cache: bundler
 notifications:
   slack:
     secure: OhClKo2Gn26gevN773CRR2NAHzmkrzGrVTHsAKm4dgNFqnaBVZGNv2kzjAFsy0CEjZJw3433NtaJdrWpLozdHFA5g7fhOTqB2y7Oh+8PsoS4qWsosKcjtCYt7BmNbEFkGaHKAdQjO/vGFml7tAOk/DtVRnfX6QgVUBjky2ao7XM=
-
-

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -16,16 +16,15 @@ Gem::Specification.new do |spec|
   spec.files         = %w{LICENSE.txt README.md} + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:lib/)}i }
   spec.test_files    = %w{Gemfile specinfra.gemspec Rakefile} + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:spec/)}i }
   spec.require_paths = ["lib"]
-  # TODO: at some point pin to a minumum version of ruby to reduce support burden in a major version bump
-  # spec.required_ruby_version  = '>= 2.3.0'
+  spec.required_ruby_version  = '>= 2.6.0'
 
   spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "net-ssh", ">= 2.7"
   # TODO: remove the lock when you want to remove ruby < 2.3 support
-  spec.add_runtime_dependency "net-telnet", "0.1.1"
+  spec.add_runtime_dependency "net-telnet"
   spec.add_runtime_dependency "sfl"
 
-  spec.add_development_dependency "rake", "~> 10.1.1"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"
 end


### PR DESCRIPTION
This enables specinfra to be tested on latest ruby versions and use latest dependencies (mostly net-telnet)