### PR TITLE
Remove fallback from checking services to checking processes

### DIFF
--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -10,7 +10,7 @@ module Specinfra
       return false if ret.stdout =~ /stop(ped)?\/waiting/
 
       # If the service is not registered, check by ps command
-      if ret.exit_status == 1
+      if ret.exit_status == 1 && !Specinfra.configuration.no_service_process_fallback
         cmd = Specinfra.command.get(:check_process_is_running, service)
         ret = Specinfra.backend.run_command(cmd)
       end


### PR DESCRIPTION
This fallback is not documented and caused issues for me. A process was running with a similar name to a service I want to check, and so I got incorrect results.

In my opinion, if someone writes `service('foobar')` they want to only check the service 'foobar', and do not want to also check for processes named 'foobar'. If they want to check the process, they can write `process('foobar')`.