### PR TITLE
Make host_inventory["kernel"]["machine"] always available

### DIFF
--- a/lib/specinfra/command/darwin/base/inventory.rb
+++ b/lib/specinfra/command/darwin/base/inventory.rb
@@ -8,6 +8,10 @@ class Specinfra::Command::Darwin::Base::Inventory < Specinfra::Command::Base::In
       'false'
     end
 
+    def get_kernel
+      'false'
+    end
+
     def get_hostname
       'hostname -s'
     end

--- a/spec/host_inventory/darwin/kernel_spec.rb
+++ b/spec/host_inventory/darwin/kernel_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Specinfra::HostInventory::Kernel do
+  describe "get" do
+    let(:host_inventory) { Specinfra::HostInventory.instance }
+    let(:command_class) { Specinfra::Command::Darwin::Base }
+    let(:error_message) { "get_kernel is not implemented in #{command_class}" }
+    let(:kernel_inventory) { Specinfra::HostInventory::Kernel.new(host_inventory) }
+    let(:result) { kernel_inventory.get }
+    example "it includes the value of os_info[:arch] in the key 'machine'" do
+      expect(result).to include(
+        "machine" => host_inventory.backend.os_info[:arch]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Since `get_kernel` inventory command is unavailable on Darwin, the value of `host_inventory["kernel"]["machine"]` is unavailable though it is provided from `os_info`:

```
$ ruby -Ilib -rspecinfra -e "p Specinfra::HostInventory.instance['kernel']['machine']"
No backend type is specified. Fall back to :exec type.
/Users/mrkn/src/github.com/mizzy/specinfra/lib/specinfra/command_factory.rb:20:in `get': get_kernel is not implemented in Specinfra::Command::Darwin::Base::Inventory (NotImplementedError)
	from /Users/mrkn/src/github.com/mizzy/specinfra/lib/specinfra/host_inventory/kernel.rb:8:in `get'
	from /Users/mrkn/src/github.com/mizzy/specinfra/lib/specinfra/host_inventory.rb:42:in `[]'
	from -e:1:in `<main>'
```

Ignoring `NotImplementedError` occurred in `CommandFactory#get` makes it always available.