### PR TITLE
fix get_block_device

### DIFF
--- a/lib/specinfra/command/linux/base/inventory.rb
+++ b/lib/specinfra/command/linux/base/inventory.rb
@@ -30,7 +30,7 @@ class Specinfra::Command::Linux::Base::Inventory < Specinfra::Command::Base::Inv
 
     def get_block_device
       block_device_dirs = '/sys/block/*/{size,removable,device/{model,rev,state,timeout,vendor},queue/rotational}'
-      "for f in $(ls #{block_device_dirs}); do echo -e \"${f}\t$(cat ${f})\"; done"
+      %Q[bash -c 'for f in $(ls #{block_device_dirs}); do echo -e "${f}\t$(cat ${f})"; done']
     end
 
     def get_system_product_name

--- a/spec/command/linux/inventory_spec.rb
+++ b/spec/command/linux/inventory_spec.rb
@@ -16,5 +16,5 @@ end
 
 describe get_command(:get_inventory_block_device) do
   block_device_dirs = '/sys/block/*/{size,removable,device/{model,rev,state,timeout,vendor},queue/rotational}'
-  it { should eq "for f in $(ls #{block_device_dirs}); do echo -e \"${f}\t$(cat ${f})\"; done" }
+  it { should eq %Q[bash -c 'for f in $(ls #{block_device_dirs}); do echo -e "${f}\t$(cat ${f})"; done'] }
 end


### PR DESCRIPTION
get_block_device command use brace expansion but sh doesn't support it.

I think the commands should be execeted via bash.

### example (after fix)
```rb
irb(main):001:0> require 'specinfra'
=> true
irb(main):002:0> backend = Specinfra::Backend::Exec.new
=> #<Specinfra::Backend::Exec:0x00005598189ffbb8 @config={}, @example=nil>
irb(main):003:0> host_inventory = Specinfra::HostInventory.new(backend)
=> #<Specinfra::HostInventory:0x00005598189e99d0 @backend=#<Specinfra::Backend::Exec:0x00005598189ffbb8 @config={}, @example=nil>, @inventory={}>
irb(main):004:0> block_device = Specinfra::HostInventory::BlockDevice.new(host_inventory)
=> #<Specinfra::HostInventory::BlockDevice:0x00005598189aac58 @host_inventory=#<Specinfra::HostInventory:0x00005598189e99d0 @backend=#<Specinfra::Backend::Exec:0x00005598189ffbb8 @config={}, @example=nil>, @inventory={}>>
irb(main):005:0> block_device.get
=> {"loop0"=>{"rotational"=>"1", "removable"=>"0", "size"=>"0"}, "loop1"=>{"rotational"=>"1", "removable"=>"0", "size"=>"0"}, "loop2"=>{"rotational"=>"1", "removable"=>"0", "size"=>"0"}, "loop3"=>{"rotational"=>"1", "removable"=>"0", "size"=>"0"}, "loop4"=>{"rotational"=>"1", "removable"=>"0", "size"=>"0"}, "loop5"=>{"rotational"=>"1", "removable"=>"0", "size"=>"0"}, "loop6"=>{"rotational"=>"1", "removable"=>"0", "size"=>"0"}, "loop7"=>{"rotational"=>"1", "removable"=>"0", "size"=>"0"}, "sda"=>{"model"=>"VBOX HARDDISK", "rev"=>"1.0", "state"=>"running", "timeout"=>"30", "vendor"=>"ATA", "rotational"=>"1", "removable"=>"0", "size"=>"83886080"}, "sdb"=>{"model"=>"VBOX HARDDISK", "rev"=>"1.0", "state"=>"running", "timeout"=>"30", "vendor"=>"ATA", "rotational"=>"0", "removable"=>"0", "size"=>"8388608"}}
```