### PR TITLE
Replace obsolete File.exists? with File.exist?

### DIFF
--- a/lib/specinfra/backend/cmd.rb
+++ b/lib/specinfra/backend/cmd.rb
@@ -70,7 +70,7 @@ module Specinfra
       end
 
       def find_powershell(dirs)
-        ( dirs.map { |dir| "#{ENV['WINDIR']}\\#{dir}\\WindowsPowerShell\\v1.0\\powershell.exe" } ).find { |exe| File.exists?(exe) } || 'powershell'
+        ( dirs.map { |dir| "#{ENV['WINDIR']}\\#{dir}\\WindowsPowerShell\\v1.0\\powershell.exe" } ).find { |exe| File.exist?(exe) } || 'powershell'
       end
 
     end


### PR DESCRIPTION
It's removed as of Ruby 3.2

FYI: https://github.com/fluent/fluent-package-builder/pull/425#issuecomment-1406190223