### PR TITLE
add KDE Neon support

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -223,6 +223,10 @@ require 'specinfra/command/linuxmint/base'
 require 'specinfra/command/elementary'
 require 'specinfra/command/elementary/base'
 
+# Neon (inherit Ubuntu)
+require 'specinfra/command/neon'
+require 'specinfra/command/neon/base'
+
 # Cumulus Networks (inherit Debian)
 require 'specinfra/command/cumulus'
 require 'specinfra/command/cumulus/base'

--- a/lib/specinfra/command/neon.rb
+++ b/lib/specinfra/command/neon.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Neon; end

--- a/lib/specinfra/command/neon/base.rb
+++ b/lib/specinfra/command/neon/base.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Neon::Base < Specinfra::Command::Ubuntu::Base
+end


### PR DESCRIPTION
Trying out Itamae for local laptop management and found that Neon support was missing in specinfra.  This adds it in. :)

Test itamae recipe:
```
http_request 'testing' do
  url "https://raw.githubusercontent.com/mizzy/specinfra/master/examples/multiple_backends.rb"
  action :get
  mode '0644'
end
```

Results:
```
itamae local test.rb
 INFO : Starting Itamae... 
 INFO : Recipe: /home/[snipped]/test.rb
 INFO :   http_request[testing] modified will change from 'false' to 'true'
 INFO :   http_request[testing] mode will be '0644'
 INFO :   diff:
 INFO :   --- testing (BEFORE)
 INFO :   +++ testing (AFTER)
 INFO :   @@ -0,0 +1,46 @@
 INFO :   +require 'specinfra'
 INFO :   +require 'pp'
```