### PR TITLE
Add VyOS Support

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -233,6 +233,10 @@ require 'specinfra/command/cumulus/base'
 require 'specinfra/command/cumulus/base/ppa'
 require 'specinfra/command/cumulus/base/service'
 
+# VyOS (inherit Debian)
+require 'specinfra/command/vyos'
+require 'specinfra/command/vyos/base'
+
 # Gentoo (inherit Linux)
 require 'specinfra/command/gentoo'
 require 'specinfra/command/gentoo/base'

--- a/lib/specinfra/command/vyos.rb
+++ b/lib/specinfra/command/vyos.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Vyos; end

--- a/lib/specinfra/command/vyos/base.rb
+++ b/lib/specinfra/command/vyos/base.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Vyos::Base < Specinfra::Command::Debian::Base
+end


### PR DESCRIPTION
This PR adds support for [VyOS](https://vyos.io/).

Test:
```rb
http_request 'testing' do
  url "https://raw.githubusercontent.com/mizzy/specinfra/master/examples/multiple_backends.rb"
  action :get
  mode '0644'
end
```

Before:
```
$ itamae ssh -h <host> testing.rb
 INFO : Starting Itamae... 
 INFO : Recipe: /Users/**/testing.rb
/**/gems/specinfra-2.85.1/lib/specinfra/command_factory.rb:31:in `create_command_class': uninitialized constant Specinfra::Command::Vyos (NameError)

    os_class     = family.nil? ? base_class : common_class.const_get(family.capitalize)
                                                          ^^^^^^^^^^
```

After:
```
$ itamae ssh -h <host> testing.rb
INFO : Starting Itamae... 
 INFO : Recipe: /Users/**/testing.rb
 INFO :   http_request[testing] modified will change from 'false' to 'true'
 INFO :   http_request[testing] mode will be '0644'
 INFO :   diff:
 INFO :   --- testing (BEFORE)
 INFO :   +++ testing (AFTER)
 INFO :   @@ -0,0 +1,46 @@
 INFO :   +require 'specinfra'
 INFO :   +require 'pp'
 INFO :   +
...
```