### PR TITLE
Add support for Amazon Linux 2023

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -134,6 +134,9 @@ require 'specinfra/command/amazon/v2022/port'
 require 'specinfra/command/amazon/v2022/service'
 require 'specinfra/command/amazon/v2022/yumrepo'
 
+# Amazon Linux V2023 (inherit Amazon Linux V2022)
+require 'specinfra/command/amazon/v2023'
+
 # AIX (inherit Base)
 require 'specinfra/command/aix'
 require 'specinfra/command/aix/base'

--- a/lib/specinfra/command/amazon/v2023.rb
+++ b/lib/specinfra/command/amazon/v2023.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Amazon::V2023 < Specinfra::Command::Amazon::V2022
+end


### PR DESCRIPTION
All relevant behavior should be identical to Amazon Linux 2022. I'm not sure if any other files are needed, but this change works well in my testing.