### PR TITLE
Use newer version of dependency or omit one for newer Ruby version

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -1,7 +1,7 @@
 require 'singleton'
 require 'fileutils'
 require 'shellwords'
-require 'sfl'
+require 'sfl' if Specinfra.ruby_is_older_than?(1, 9, 0)
 
 module Specinfra
   module Backend

--- a/lib/specinfra/version.rb
+++ b/lib/specinfra/version.rb
@@ -1,3 +1,7 @@
 module Specinfra
   VERSION = "2.87.0"
+
+  def self.ruby_is_older_than?(*version)
+    (RUBY_VERSION.split('.').map(&:to_i) <=> version) < 0
+  end
 end

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "net-ssh", ">= 2.7"
-  # TODO: remove the lock when you want to remove ruby < 2.3 support
-  spec.add_runtime_dependency "net-telnet", "0.1.1"
+  spec.add_runtime_dependency "net-telnet", *(Specinfra.ruby_is_older_than?(2, 3, 0) ? ["0.1.1"] : [])
   spec.add_runtime_dependency "sfl" if Specinfra.ruby_is_older_than?(1, 9, 0)
 
   spec.add_development_dependency "rake", "~> 10.1.1"

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "net-ssh", ">= 2.7"
   # TODO: remove the lock when you want to remove ruby < 2.3 support
   spec.add_runtime_dependency "net-telnet", "0.1.1"
-  spec.add_runtime_dependency "sfl"
+  spec.add_runtime_dependency "sfl" if Specinfra.ruby_is_older_than?(1, 9, 0)
 
   spec.add_development_dependency "rake", "~> 10.1.1"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Hello,

This will change the dependencies according to the Ruby version:

* `sfl`: Add the dependency only if Ruby is older than 1.9.0.
* `net-telnet`: Use the version newer than 0.1.1 if Ruby version is 2.3.0 or higher.

Thank you,