### PR TITLE
Remove version constraints in gemspec and some CI workflow fixes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,6 @@ jobs:
         - 1.9.3
         - 2.0.0
         - 2.1.9
-        - 2.2.10
         - 2.3.8
         - 2.4.10
         - 2.5.9
@@ -23,6 +22,31 @@ jobs:
         - 3.0.6
         - 3.1.4
         - 3.2.2
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run tests
+        run: bundle exec rake
+
+  # Bundler with Ruby 2.2.10 doesn't work for the latest Ubuntu.
+  # See also: https://github.com/ruby/setup-ruby/issues/496#issuecomment-1625000309
+  test-ruby-2-2-10:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - 2.2.10
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Or install it yourself as:
   gem install specinfra
   ```
 
+For Ruby versions older than 2.3.0, pin net-telnet to version 0.1.1 in your `Gemfile` or `*.gemspec`.
+See also [pin net-telnet dependency to keep ruby support for < 2.3 #665][issue665].
+
+[issue665]: https://github.com/mizzy/specinfra/pull/665
+
 ## Running tests
 
   ```

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -18,7 +18,7 @@ describe Specinfra::Backend::Exec do
       end
 
       it 'should escape quotes' do
-        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
+        if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.7')
           expect(Specinfra.backend.build_command(%Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\\"']?http://ppa.launchpad.net/gluster/glusterfs-3.7"})).to eq('/bin/sh -c find\ /etc/apt/\ -name\ \*.list\ \|\ xargs\ grep\ -o\ -E\ \"\^deb\ \+\[\\\\\"\\\'\]\?http://ppa.launchpad.net/gluster/glusterfs-3.7\"')
         else
           # Since Ruby 2.7, `+` is not escaped.

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "net-ssh", ">= 2.7"
-  spec.add_runtime_dependency "net-telnet", *(Specinfra.ruby_is_older_than?(2, 3, 0) ? ["0.1.1"] : [])
-  spec.add_runtime_dependency "sfl" if Specinfra.ruby_is_older_than?(1, 9, 0)
+  spec.add_runtime_dependency "net-telnet"
+  spec.add_runtime_dependency "sfl"
 
   spec.add_development_dependency "rake", "~> 10.1.1"
   spec.add_development_dependency "rspec"

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "net-ssh", ">= 2.7"
-  spec.add_runtime_dependency "net-telnet"
-  spec.add_runtime_dependency "sfl"
+  spec.add_runtime_dependency "net-telnet" # intentionally version-unspecified for Ruby older than 2.3.0
+  spec.add_runtime_dependency "sfl" # required for Ruby older than 1.9.0
 
   spec.add_development_dependency "rake", "~> 10.1.1"
   spec.add_development_dependency "rspec"

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "net-telnet" # intentionally version-unspecified for Ruby older than 2.3.0
   spec.add_runtime_dependency "sfl" # required for Ruby older than 1.9.0
 
-  spec.add_development_dependency "rake", "~> 10.1.1"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"
 end


### PR DESCRIPTION
This is a continuation of #746.

The summary of changes are bellow:

* Remove gem version conditionals in the gemspec file, which is evaluated in release phase, so one cannot use conditionals in the file.  This is a regression of #746.
* Use an unfrozen string value in the test code.  This passes the test workflow for the Ruby v.1.9.3.
* Remove Rake version constraint from the gemspec file.  Older Rake has an issue with the latest Ruby version.
* Use Ubuntu 20.04 for Ruby 2.2.10.  Bundler cannot be installed with Ruby 2.2.10 on the latest Ubuntu.

Please refer also to the pointers in commit messages.

Best,