### PR TITLE
host_inventory/linux/virtualization: Fallback to systemd-detect-virt

### DIFF
--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -17,8 +17,8 @@ module Specinfra
 
         cmd = backend.command.get(:get_inventory_system_product_name)
         ret = backend.run_command(cmd)
-        if ret.exit_status == 0 and ret.stdout.length > 0
-           res[:system] = parse_system_product_name(ret.stdout)
+        if ret.success? and (parsed = parse_system_product_name(ret.stdout))
+           res[:system] = parsed
            return res
         end
 

--- a/spec/host_inventory/linux/virtualization_spec.rb
+++ b/spec/host_inventory/linux/virtualization_spec.rb
@@ -25,6 +25,22 @@ describe Specinfra::HostInventory::Virtualization do
     expect(virt.get).to include(:system => 'openvz')
   end
 
+  it 'Debian on QEMU KVM should return :system => "kvm"' do
+    allow(virt.backend).to receive(:run_command).with('grep -Eqa \'docker(/|-[0-9a-f]+)\' /proc/1/cgroup||test -e /.dockerinit') do
+      CommandResult.new(:stdout => '', :exit_status => 1)
+    end
+    allow(virt.backend).to receive(:run_command).with('test -d /proc/vz -a ! -d /proc/bc') do
+      CommandResult.new(:stdout => '', :exit_status => 1)
+    end
+    allow(virt.backend).to receive(:run_command).with('dmidecode -s system-product-name') do
+      CommandResult.new(:stdout => "Standard PC (Q35 + ICH9, 2009)\n", :exit_status => 0)
+    end
+    allow(virt.backend).to receive(:run_command).with('systemd-detect-virt') do
+      CommandResult.new(:stdout => "kvm\n", :exit_status => 0)
+    end
+    expect(virt.get).to include(:system => 'kvm')
+  end
+
   let(:host_inventory) { nil }
   it 'Debian Jessie on KVM should return :system => "kvm"' do
     ret = virt.parse_system_product_name("KVM\n")


### PR DESCRIPTION
In detecting virtualization, if system-product-name from DMI is unknown to Specinfra, fallback to `systemd-detect-virt`, which has better heuristics. It currently returns `{system: nil}` in such a case.