### PR TITLE
Add base64 as runtime dependency

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   # TODO: at some point pin to a minumum version of ruby to reduce support burden in a major version bump
   # spec.required_ruby_version  = '>= 2.3.0'
 
+  spec.add_runtime_dependency "base64"
   spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "net-ssh", ">= 2.7"
   spec.add_runtime_dependency "net-telnet" # intentionally version-unspecified for Ruby older than 2.3.0


### PR DESCRIPTION
Fixed the following warning when running `serverspec` on Ruby 3.3

```bash
$ ruby --version
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]

$ bundle exec rspec
/app/vendor/bundle/ruby/3.3.0/gems/specinfra-2.90.0/lib/specinfra/backend/powershell/script_helper.rb:1: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of specinfra-2.90.0 to add base64 into its gemspec.
```

See "Standard library updates" section in https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/