### PR TITLE
Clear BUNDLER_SETUP env in exec

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -141,7 +141,7 @@ module Specinfra
       end
 
       def with_env
-        keys = %w[BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE
+        keys = %w[BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE BUNDLER_SETUP
             RUBYOPT GEM_HOME GEM_PATH GEM_CACHE]
 
         keys.each { |key| ENV["_SPECINFRA_#{key}"] = ENV[key] ; ENV.delete(key) }

--- a/spec/backend/exec/env_spec.rb
+++ b/spec/backend/exec/env_spec.rb
@@ -6,7 +6,7 @@ describe Specinfra.backend.run_command('echo $LANG').stdout.strip do
   it { should eq 'C' }
 end
 
-describe do
+describe "override ENV with config(:env)" do
   before do
     set :backend, :exec
 
@@ -18,3 +18,11 @@ describe do
   it { expect(ENV['LANG']).to eq 'C' }
 end
 
+describe "clear env for BUNDLER" do
+  before do
+    set :backend, :exec
+
+    ENV['BUNDLER_SETUP'] = 'any-value'
+  end
+  it { expect(Specinfra.backend.run_command('printenv BUNDLER_SETUP').stdout).to eq '' }
+end


### PR DESCRIPTION
In bundler >= 2.4 and rubygems >= 3.4, "BUNDLER_SETUP" environment variable affects the bundle command execution.

So I have clear it.