### PR TITLE
Detect Debian Testing and assign a impossibly high version number

### DIFF
--- a/lib/specinfra/helper/detect_os/debian.rb
+++ b/lib/specinfra/helper/detect_os/debian.rb
@@ -20,6 +20,7 @@ class Specinfra::Helper::DetectOs::Debian < Specinfra::Helper::DetectOs
       end
       distro ||= 'debian'
       release ||= nil
+      release = "testing" if distro =~ /debian/i && release == "n/a" && debian_version.stdout.strip =~ /\w+\/sid$/
       { :family => distro.gsub(/[^[:alnum:]]/, '').downcase, :release => release }
     end
   end

--- a/spec/helper/detect_os/debian_spec.rb
+++ b/spec/helper/detect_os/debian_spec.rb
@@ -64,4 +64,19 @@ describe Specinfra::Helper::DetectOs::Debian do
       :release => '16.04'
     )
   end
+  it 'Should return debian testing when lsb_release says release = n/a' do
+    allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
+      CommandResult.new(:stdout => "bookworm/sid", :exit_status => 0)
+    }
+    allow(debian).to receive(:run_command).with('lsb_release -ir') {
+      CommandResult.new(:stdout => "Distributor ID:	Debian\nRelease:	n/a\n", :exit_status => 0)
+    }
+    allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
+      CommandResult.new(:stdout => "", :exit_status => 1)
+    }
+    expect(debian.detect).to include(
+      :family  => 'debian',
+      :release => 'testing'
+    )
+  end
 end

--- a/spec/helper/detect_os/debian_spec.rb
+++ b/spec/helper/detect_os/debian_spec.rb
@@ -76,7 +76,7 @@ describe Specinfra::Helper::DetectOs::Debian do
     }
     expect(debian.detect).to include(
       :family  => 'debian',
-      :release => 'testing'
+      :release => 4294967295.0
     )
   end
 end


### PR DESCRIPTION
Debian is nearing its next release so it would be nice if `os[:release]` is not `nil` on Debian Testing/Trixie. This is a rework of #741, for a rationale of this implementation see https://github.com/mizzy/specinfra/pull/741#issuecomment-1836279113 