### PR TITLE
feat: Add `platform_codename` host inventory

### DIFF
--- a/lib/specinfra/helper/detect_os/debian.rb
+++ b/lib/specinfra/helper/detect_os/debian.rb
@@ -1,17 +1,36 @@
 class Specinfra::Helper::DetectOs::Debian < Specinfra::Helper::DetectOs
   def detect
     if (debian_version = run_command('cat /etc/debian_version')) && debian_version.success?
-      distro  = nil
-      release = nil
-      if (lsb_release = run_command("lsb_release -ir")) && lsb_release.success?
+      distro   = nil
+      release  = nil
+      codename = nil
+      if (lsb_release = run_command("lsb_release -irc")) && lsb_release.success?
         lsb_release.stdout.each_line do |line|
-          distro  = line.split(':').last.strip if line =~ /^Distributor ID:/
-          release = line.split(':').last.strip if line =~ /^Release:/
+          distro   = line.split(':').last.strip if line =~ /^Distributor ID:/
+          release  = line.split(':').last.strip if line =~ /^Release:/
+          codename = line.split(':').last.strip if line =~ /^Codename:/
         end
       elsif (lsb_release = run_command("cat /etc/lsb-release")) && lsb_release.success?
         lsb_release.stdout.each_line do |line|
-          distro  = line.split('=').last.strip if line =~ /^DISTRIB_ID=/
-          release = line.split('=').last.strip if line =~ /^DISTRIB_RELEASE=/
+          distro   = line.split('=').last.strip if line =~ /^DISTRIB_ID=/
+          release  = line.split('=').last.strip if line =~ /^DISTRIB_RELEASE=/
+          codename = line.split('=').last.strip if line =~ /^DISTRIB_CODENAME=/
+        end
+      elsif (lsb_release = run_command("cat /etc/os-release")) && lsb_release.success?
+        lsb_release.stdout.each_line do |line|
+          distro   = line.split('=').last.delete('"').strip if line =~ /^ID=/
+          release  = line.split('=').last.delete('"').strip if line =~ /^VERSION_ID=/
+          codename = line.split('=').last.delete('"').strip if line =~ /^VERSION_CODENAME=/
+        end
+        # There is no codename notation until Debian Jessie
+        if codename.nil?
+          lsb_release.stdout.each_line do |line|
+            version = line.split('=').last.delete('"').strip if line =~ /^VERSION=/
+            # For debian releases
+            if m = /^[0-9]+ \((\w+)\)$/.match(version)
+              codename = m[1]
+            end
+          end
         end
       end
       distro ||= 'debian'
@@ -27,7 +46,7 @@ class Specinfra::Helper::DetectOs::Debian < Specinfra::Helper::DetectOs
                     nil
                   end
       end
-      { :family => distro.gsub(/[^[:alnum:]]/, '').downcase, :release => release }
+      { :family => distro.gsub(/[^[:alnum:]]/, '').downcase, :release => release, :codename => codename }
     end
   end
 end

--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -7,6 +7,7 @@ module Specinfra
       domain
       fqdn
       platform
+      platform_codename
       platform_version
       filesystem
       cpu

--- a/lib/specinfra/host_inventory/platform_codename.rb
+++ b/lib/specinfra/host_inventory/platform_codename.rb
@@ -1,0 +1,9 @@
+module Specinfra
+  class HostInventory
+    class PlatformCodename < Base
+      def get
+        backend.os_info[:codename]
+      end
+    end
+  end
+end

--- a/spec/backend/exec/build_command_spec.rb
+++ b/spec/backend/exec/build_command_spec.rb
@@ -124,11 +124,11 @@ describe 'os' do
   context 'test ubuntu with lsb_release command' do
     before do
       allow(Specinfra.backend).to receive(:run_command) do |args|
-        if ['cat /etc/debian_version', 'lsb_release -ir'].include? args
+        if ['cat /etc/debian_version', 'lsb_release -irc'].include? args
           double(
             :run_command_response,
             :success? => true,
-            :stdout => "Distributor ID:\tUbuntu\nRelease:\t12.04\n"
+            :stdout => "Distributor ID:\tUbuntu\nRelease:\t12.04\nCodename:\tprecise\n"
           )
         elsif args == 'uname -m'
           double :run_command_response, :success? => true, :stdout => "x86_64\n"
@@ -140,7 +140,7 @@ describe 'os' do
     subject! { os }
     it do
       expect(Specinfra.backend).to have_received(:run_command).at_least(1).times
-      should eq({:family => 'ubuntu', :release => '12.04', :arch => 'x86_64' })
+      should eq({:family => 'ubuntu', :release => '12.04', :codename => 'precise', :arch => 'x86_64' })
     end
   end
 
@@ -168,7 +168,7 @@ EOF
     subject! { os }
     it do
       expect(Specinfra.backend).to have_received(:run_command).at_least(1).times
-      should eq({:family => 'ubuntu', :release => '12.04', :arch => 'x86_64' })
+      should eq({:family => 'ubuntu', :release => '12.04', :codename => 'precise', :arch => 'x86_64' })
     end
   end
 
@@ -187,7 +187,7 @@ EOF
     subject! { os }
     it do
       expect(Specinfra.backend).to have_received(:run_command).at_least(1).times
-      should eq({:family => 'debian', :release => '8.5', :arch => 'x86_64' })
+      should eq({:family => 'debian', :release => '8.5', :codename => nil, :arch => 'x86_64' })
     end
   end
 end

--- a/spec/helper/detect_os/debian_spec.rb
+++ b/spec/helper/detect_os/debian_spec.rb
@@ -4,79 +4,118 @@ require 'specinfra/helper/detect_os/debian'
 describe Specinfra::Helper::DetectOs::Debian do
   debian = Specinfra::Helper::DetectOs::Debian.new(Specinfra.backend)
 
+  it 'Should return debian 7 wheezy is installed.' do
+    allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
+      CommandResult.new(:stdout => "", :exit_status => 0)
+    }
+    allow(debian).to receive(:run_command).with('lsb_release -irc') {
+      CommandResult.new(:stdout => "", :exit_status => 1)
+    }
+    allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
+      CommandResult.new(:stdout => "", :exit_status => 1)
+    }
+    allow(debian).to receive(:run_command).with('cat /etc/os-release') {
+      CommandResult.new(:stdout => "VERSION_ID=\"7\"\nVERSION=\"7 (wheezy)\"\nID=debian\n", :exit_status => 0)
+    }
+    expect(debian.detect).to include(
+      :family   => 'debian',
+      :release  => '7',
+      :codename => 'wheezy'
+    )
+  end
   it 'Should return debian 8.5 when jessie is installed.' do
     allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
       CommandResult.new(:stdout => "8.5\n", :exit_status => 0)
     }
-    allow(debian).to receive(:run_command).with('lsb_release -ir') {
+    allow(debian).to receive(:run_command).with('lsb_release -irc') {
       CommandResult.new(:stdout => "8.5\n", :exit_status => 1)
     }
     allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
       CommandResult.new(:stdout => "8.5\n", :exit_status => 1)
     }
+    allow(debian).to receive(:run_command).with('cat /etc/os-release') {
+      CommandResult.new(:stdout => "8.5\n", :exit_status => 1)
+    }
     expect(debian.detect).to include(
-      :family  => 'debian',
-      :release => '8.5'
+      :family   => 'debian',
+      :release  => '8.5',
+      :codename => nil
     )
   end
   it 'Should return ubuntu 16.10 when yakkety is installed.' do
     allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
       CommandResult.new(:stdout => "stretch/sid", :exit_status => 0)
     }
-    allow(debian).to receive(:run_command).with('lsb_release -ir') {
-      CommandResult.new(:stdout => "Distributor ID:Ubuntu\nRelease:16.10\n", :exit_status => 0)
+    allow(debian).to receive(:run_command).with('lsb_release -irc') {
+      CommandResult.new(:stdout => "Distributor ID:Ubuntu\nRelease:16.10\nCodename:yakkety\n", :exit_status => 0)
     }
     allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
       CommandResult.new(:stdout => "DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=16.10\nDISTRIB_CODENAME=yakkety\nDISTRIB_DESCRIPTION=\"Ubuntu 16.10\"", :exit_status => 0)
     }
+    allow(debian).to receive(:run_command).with('cat /etc/os-release') {
+      CommandResult.new(:stdout => "", :exit_status => 1)
+    }
     expect(debian.detect).to include(
-      :family  => 'ubuntu',
-      :release => '16.10'
+      :family   => 'ubuntu',
+      :release  => '16.10',
+      :codename => 'yakkety'
     )
   end
   it 'Should return ubuntu 16.04 when xenial is installed.' do
     allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
       CommandResult.new(:stdout => "stretch/sid", :exit_status => 0)
     }
-    allow(debian).to receive(:run_command).with('lsb_release -ir') {
-      CommandResult.new(:stdout => "Distributor ID:Ubuntu\nRelease:16.04\n", :exit_status => 0)
+    allow(debian).to receive(:run_command).with('lsb_release -irc') {
+      CommandResult.new(:stdout => "Distributor ID:Ubuntu\nRelease:16.04\nCodename:xenial\n", :exit_status => 0)
     }
     allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
       CommandResult.new(:stdout => "DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=16.04\nDISTRIB_CODENAME=xenial\nDISTRIB_DESCRIPTION=\"Ubuntu 16.04.2 LTS\"", :exit_status => 0)
     }
+    allow(debian).to receive(:run_command).with('cat /etc/os-release') {
+      CommandResult.new(:stdout => "", :exit_status => 1)
+    }
     expect(debian.detect).to include(
-      :family  => 'ubuntu',
-      :release => '16.04'
+      :family   => 'ubuntu',
+      :release  => '16.04',
+      :codename => 'xenial'
     )
   end
   it 'Should return ubuntu 16.04 when xenial is installed in docker.' do
     allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
       CommandResult.new(:stdout => "stretch/sid", :exit_status => 0)
     }
-    allow(debian).to receive(:run_command).with('lsb_release -ir') {
+    allow(debian).to receive(:run_command).with('lsb_release -irc') {
       CommandResult.new(:stdout => 'lsb-release is not installed in docker image by default', :exit_status => 1)
     }
     allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
       CommandResult.new(:stdout => "DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=16.04\nDISTRIB_CODENAME=xenial\nDISTRIB_DESCRIPTION=\"Ubuntu 16.04.2 LTS\"", :exit_status => 0)
     }
+    allow(debian).to receive(:run_command).with('cat /etc/os-release') {
+      CommandResult.new(:stdout => "", :exit_status => 1)
+    }
     expect(debian.detect).to include(
-      :family  => 'ubuntu',
-      :release => '16.04'
+      :family   => 'ubuntu',
+      :release  => '16.04',
+      :codename => 'xenial'
     )
   end
   it 'Should return debian testing when lsb_release says release = n/a' do
     allow(debian).to receive(:run_command).with('cat /etc/debian_version') {
       CommandResult.new(:stdout => "bookworm/sid", :exit_status => 0)
     }
-    allow(debian).to receive(:run_command).with('lsb_release -ir') {
-      CommandResult.new(:stdout => "Distributor ID:	Debian\nRelease:	n/a\n", :exit_status => 0)
+    allow(debian).to receive(:run_command).with('lsb_release -irc') {
+      CommandResult.new(:stdout => "Distributor ID:	Debian\nRelease:\tn/a\nCodename:\ttrixie\n", :exit_status => 0)
     }
     allow(debian).to receive(:run_command).with('cat /etc/lsb-release') {
       CommandResult.new(:stdout => "", :exit_status => 1)
     }
+    allow(debian).to receive(:run_command).with('cat /etc/os-release') {
+      CommandResult.new(:stdout => "", :exit_status => 1)
+    }
     expect(debian.detect).to include(
-      :family  => 'debian',
-      :release => 4294967295.0
+      :family   => 'debian',
+      :release  => 4294967295.0,
+      :codename => 'trixie'
     )
   end
 end


### PR DESCRIPTION
In Debian and Ubuntu, codenames are used in various places, such as APT repository settings.

If the codenames can be obtained from the host inventory, users will no longer need to check the /etc/os-release file individually.