### PR TITLE
fix 'stack level too deep' caused by local re-definition of Class#subclasses

### DIFF
--- a/lib/specinfra/ext/class.rb
+++ b/lib/specinfra/ext/class.rb
@@ -1,11 +1,13 @@
 class Class
-  def subclasses
-    result = []
-    ObjectSpace.each_object(Class) do |k|
-      next unless k < self
-      next if k.respond_to?(:singleton_class?) && k.singleton_class?
-      result << k
+  if !self.method_defined?(:subclasses)
+    def subclasses
+      result = []
+      ObjectSpace.each_object(Class) do |k|
+        next unless k < self
+        next if k.respond_to?(:singleton_class?) && k.singleton_class?
+        result << k
+      end
+      result
     end
-    result
   end
 end

--- a/lib/specinfra/version.rb
+++ b/lib/specinfra/version.rb
@@ -1,5 +1,5 @@
 module Specinfra
-  VERSION = "2.94.0"
+  VERSION = "2.94.1"
 
   def self.ruby_is_older_than?(*version)
     (RUBY_VERSION.split('.').map(&:to_i) <=> version) < 0


### PR DESCRIPTION
### Phenomenon

When invoke any command like 'rake db:create' which the project depends on ruby >= 3.1 and specinfra, it causes

> rake aborted!
> SystemStackError: stack level too deep (SystemStackError)
> ...

because spcinfra redefines Class#subclasses while ruby (>= 3.1) already have.

### How to fix

This PR fixes by define Class#subclasses only when ruby does not such a  method.
`git diff -w` would be better to see the modification of this PR.