### PR TITLE
CI seems not to be running for the last year despite recent commits

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,8 @@ name: Run test
 
 on:
   pull_request:
-    
+  push:
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -11,42 +12,16 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-        - 1.9.3
-        - 2.0.0
-        - 2.1.9
-        - 2.3.8
-        - 2.4.10
-        - 2.5.9
-        - 2.6.10
-        - 2.7.8
-        - 3.0.6
-        - 3.1.4
-        - 3.2.2
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-
-      - name: Install dependencies
-        run: bundle install
-
-      - name: Run tests
-        run: bundle exec rake
-
-  # Bundler with Ruby 2.2.10 doesn't work for the latest Ubuntu.
-  # See also: https://github.com/ruby/setup-ruby/issues/496#issuecomment-1625000309
-  test-ruby-2-2-10:
-    runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby-version:
-          - 2.2.10
+        - 2.3
+        - 2.4
+        - 2.5
+        - 2.6
+        - 2.7
+        - 3.0
+        - 3.1
+        - 3.2
+        - 3.3
+        - 3.4
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Local runs are broken out of the box.

CI is also very very out of date. 3.2 is the latest but next to EOL.

Please enable issues. This is hostile to contributions.

```
/Users/ryan/Work/p4/zss/usr/root/ansible/mitamae/specinfra/spec/host_inventory/base/user_spec.rb:38: warning: key "root" is duplicated and overwritten on line 57
..........FFFFFFFF...................................FFFFFFFFFF..................................................................................................................................................................................................................................................................................................................................................................................................................................................................F....................................................................................................

Failures:

  1) Specinfra::Backend::Exec#build_command with simple command should escape spaces
     Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq '/bin/sh -c test\ -f\ /etc/passwd'

       expected: "/bin/sh -c test\\ -f\\ /etc/passwd"
            got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

       (compared using ==)
     # ./spec/backend/exec/build_command_spec.rb:11:in 'block (4 levels) in <top (required)>'

  2) Specinfra::Backend::Exec#build_command with complex command should escape special chars
     Failure/Error: expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq '/bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)'

       expected: "/bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ \\|\\|\\ \\(getenforce\\ \\|\\ grep\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"
            got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ ...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"

       (compared using ==)
     # ./spec/backend/exec/build_command_spec.rb:17:in 'block (4 levels) in <top (required)>'

  3) Specinfra::Backend::Exec#build_command with complex command should escape quotes
     Failure/Error: expect(Specinfra.backend.build_command(%Q{find /etc/apt/ -name \*.list | xargs grep -o -E "^deb +[\\"']?http://ppa.launchpad.net/gluster/glusterfs-3.7"})).to eq('/bin/sh -c find\ /etc/apt/\ -name\ \*.list\ \|\ xargs\ grep\ -o\ -E\ \"\^deb\ +\[\\\\\"\\\'\]\?http://ppa.launchpad.net/gluster/glusterfs-3.7\"')

       expected: "/bin/sh -c find\\ /etc/apt/\\ -name\\ \\*.list\\ \\|\\ xargs\\ grep\\ -o\\ -E\\ \\\"\\^deb\\ +\\[\\\\\\\"\\'\\]\\?http://ppa.launchpad.net/gluster/glusterfs-3.7\\\""
            got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c find\\ /etc/apt/\\ -name\\ \\*.list\\ \\...ep\\ -o\\ -E\\ \\\"\\^deb\\ +\\[\\\\\\\"\\'\\]\\?http://ppa.launchpad.net/gluster/glusterfs-3.7\\\""

       (compared using ==)
     # ./spec/backend/exec/build_command_spec.rb:25:in 'block (4 levels) in <top (required)>'

  4) Specinfra::Backend::Exec#build_command with custom shell should use custom shell
     Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq '/usr/local/bin/tcsh -c test\ -f\ /etc/passwd'

       expected: "/usr/local/bin/tcsh -c test\\ -f\\ /etc/passwd"
            got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

       (compared using ==)
     # ./spec/backend/exec/build_command_spec.rb:40:in 'block (4 levels) in <top (required)>'

  5) Specinfra::Backend::Exec#build_command with custom shell that needs escaping should use custom shell
     Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq '/usr/test\ \&\ spec/bin/sh -c test\ -f\ /etc/passwd'

       expected: "/usr/test\\ \\&\\ spec/bin/sh -c test\\ -f\\ /etc/passwd"
            got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

       (compared using ==)
     # ./spec/backend/exec/build_command_spec.rb:54:in 'block (4 levels) in <top (required)>'

  6) Specinfra::Backend::Exec#build_command with an interactive shell should emulate an interactive shell
     Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq '/bin/sh -i -c test\ -f\ /etc/passwd'

       expected: "/bin/sh -i -c test\\ -f\\ /etc/passwd"
            got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

       (compared using ==)
     # ./spec/backend/exec/build_command_spec.rb:68:in 'block (4 levels) in <top (required)>'

  7) Specinfra::Backend::Exec#build_command with an login shell should emulate an login shell
     Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq '/bin/sh -l -c test\ -f\ /etc/passwd'

       expected: "/bin/sh -l -c test\\ -f\\ /etc/passwd"
            got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

       (compared using ==)
     # ./spec/backend/exec/build_command_spec.rb:82:in 'block (4 levels) in <top (required)>'

  8) Specinfra::Backend::Exec#build_command with custom path should use custom path
     Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq 'env PATH="/opt/bin:/opt/foo/bin:$PATH" /bin/sh -c test\ -f\ /etc/passwd'

       expected: "env PATH=\"/opt/bin:/opt/foo/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"
            got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

       (compared using ==)
     # ./spec/backend/exec/build_command_spec.rb:96:in 'block (4 levels) in <top (required)>'

  9) Specinfra::Backend::Ssh#build_command with root user should not prepend sudo
     Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq '/bin/sh -c test\ -f\ /etc/passwd'

       expected: "/bin/sh -c test\\ -f\\ /etc/passwd"
            got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

       (compared using ==)
     # ./spec/backend/ssh/build_command_spec.rb:30:in 'block (4 levels) in <top (required)>'

  10) Specinfra::Backend::Ssh#build_command with root user should escape special characters
      Failure/Error: expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq '/bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)'

        expected: "/bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ \\|\\|\\ \\(getenforce\\ \\|\\ grep\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"
             got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ ...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"

        (compared using ==)
      # ./spec/backend/ssh/build_command_spec.rb:34:in 'block (4 levels) in <top (required)>'

  11) Specinfra::Backend::Ssh#build_command with non-root user should prepend sudo
      Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq %q{sudo -p 'Password: ' /bin/sh -c test\ -f\ /etc/passwd}

        expected: "sudo -p 'Password: ' /bin/sh -c test\\ -f\\ /etc/passwd"
             got: "sudo -p 'Password: ' env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

        (compared using ==)
      # ./spec/backend/ssh/build_command_spec.rb:53:in 'block (4 levels) in <top (required)>'

  12) Specinfra::Backend::Ssh#build_command with non-root user should escape special characters
      Failure/Error: expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq %q{sudo -p 'Password: ' /bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)}

        expected: "sudo -p 'Password: ' /bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ \\|\\|\\ \\(getenforce\\ \\|...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"
             got: "sudo -p 'Password: ' env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ \\!\\ -f\\ /...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"

        (compared using ==)
      # ./spec/backend/ssh/build_command_spec.rb:57:in 'block (4 levels) in <top (required)>'

  13) Specinfra::Backend::Ssh#build_command with custom sudo path command pattern 1a
      Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq %q{/usr/local/bin/sudo -p 'Password: ' /bin/sh -c test\ -f\ /etc/passwd}

        expected: "/usr/local/bin/sudo -p 'Password: ' /bin/sh -c test\\ -f\\ /etc/passwd"
             got: "/usr/local/bin/sudo -p 'Password: ' env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

        (compared using ==)
      # ./spec/backend/ssh/build_command_spec.rb:78:in 'block (4 levels) in <top (required)>'

  14) Specinfra::Backend::Ssh#build_command with custom sudo path command pattern 2a
      Failure/Error: expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq %q{/usr/local/bin/sudo -p 'Password: ' /bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)}

        expected: "/usr/local/bin/sudo -p 'Password: ' /bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ \\|\\|\\ \\(g...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"
             got: "/usr/local/bin/sudo -p 'Password: ' env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"

        (compared using ==)
      # ./spec/backend/ssh/build_command_spec.rb:82:in 'block (4 levels) in <top (required)>'

  15) Specinfra::Backend::Ssh#build_command without sudo command pattern 1b
      Failure/Error: expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq '/bin/sh -c test\ -f\ /etc/passwd'

        expected: "/bin/sh -c test\\ -f\\ /etc/passwd"
             got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

        (compared using ==)
      # ./spec/backend/ssh/build_command_spec.rb:103:in 'block (4 levels) in <top (required)>'

  16) Specinfra::Backend::Ssh#build_command without sudo command pattern 2b
      Failure/Error: expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq '/bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)'

        expected: "/bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ \\|\\|\\ \\(getenforce\\ \\|\\ grep\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"
             got: "env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ ...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"

        (compared using ==)
      # ./spec/backend/ssh/build_command_spec.rb:107:in 'block (4 levels) in <top (required)>'

  17) Specinfra::Backend::Ssh#build_command with sudo on alternative path command pattern 1a is expected to eq "sudo -p 'Password: ' /bin/sh -c test\\ -f\\ /etc/passwd"
      Failure/Error: it { should eq %q{sudo -p 'Password: ' /bin/sh -c test\ -f\ /etc/passwd} }

        expected: "sudo -p 'Password: ' /bin/sh -c test\\ -f\\ /etc/passwd"
             got: "sudo -p 'Password: ' env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ -f\\ /etc/passwd"

        (compared using ==)
      # ./spec/backend/ssh/build_command_spec.rb:129:in 'block (5 levels) in <top (required)>'

  18) Specinfra::Backend::Ssh#build_command with sudo on alternative path command pattern 2a is expected to eq "sudo -p 'Password: ' /bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ \\|\\|\\ \\(getenforce\\ \\|...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"
      Failure/Error: it { should eq %q{sudo -p 'Password: ' /bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)} }

        expected: "sudo -p 'Password: ' /bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ \\|\\|\\ \\(getenforce\\ \\|...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"
             got: "sudo -p 'Password: ' env PATH=\"/opt/bin:/opt/test & spec/bin:$PATH\" /bin/sh -c test\\ \\!\\ -f\\ /...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"

        (compared using ==)
      # ./spec/backend/ssh/build_command_spec.rb:134:in 'block (5 levels) in <top (required)>'

  19) Specinfra::HostInventory::Kernel get it includes the value of os_info[:arch] in the key 'machine'
      Failure/Error: raise NotImplementedError.new("#{method} is not implemented in #{command_class}")

      NotImplementedError:
        get_kernel is not implemented in Specinfra::Command::Base::Inventory
      # ./lib/specinfra/command_factory.rb:20:in 'Specinfra::CommandFactory#get'
      # ./lib/specinfra/host_inventory/kernel.rb:8:in 'Specinfra::HostInventory::Kernel#get'
      # ./spec/host_inventory/darwin/kernel_spec.rb:9:in 'block (3 levels) in <top (required)>'
      # ./spec/host_inventory/darwin/kernel_spec.rb:11:in 'block (3 levels) in <top (required)>'

Finished in 8.88 seconds (files took 0.18374 seconds to load)
614 examples, 19 failures

Failed examples:

rspec ./spec/backend/exec/build_command_spec.rb:10 # Specinfra::Backend::Exec#build_command with simple command should escape spaces
rspec ./spec/backend/exec/build_command_spec.rb:16 # Specinfra::Backend::Exec#build_command with complex command should escape special chars
rspec ./spec/backend/exec/build_command_spec.rb:20 # Specinfra::Backend::Exec#build_command with complex command should escape quotes
rspec ./spec/backend/exec/build_command_spec.rb:39 # Specinfra::Backend::Exec#build_command with custom shell should use custom shell
rspec ./spec/backend/exec/build_command_spec.rb:53 # Specinfra::Backend::Exec#build_command with custom shell that needs escaping should use custom shell
rspec ./spec/backend/exec/build_command_spec.rb:67 # Specinfra::Backend::Exec#build_command with an interactive shell should emulate an interactive shell
rspec ./spec/backend/exec/build_command_spec.rb:81 # Specinfra::Backend::Exec#build_command with an login shell should emulate an login shell
rspec ./spec/backend/exec/build_command_spec.rb:95 # Specinfra::Backend::Exec#build_command with custom path should use custom path
rspec ./spec/backend/ssh/build_command_spec.rb:29 # Specinfra::Backend::Ssh#build_command with root user should not prepend sudo
rspec ./spec/backend/ssh/build_command_spec.rb:33 # Specinfra::Backend::Ssh#build_command with root user should escape special characters
rspec ./spec/backend/ssh/build_command_spec.rb:52 # Specinfra::Backend::Ssh#build_command with non-root user should prepend sudo
rspec ./spec/backend/ssh/build_command_spec.rb:56 # Specinfra::Backend::Ssh#build_command with non-root user should escape special characters
rspec ./spec/backend/ssh/build_command_spec.rb:77 # Specinfra::Backend::Ssh#build_command with custom sudo path command pattern 1a
rspec ./spec/backend/ssh/build_command_spec.rb:81 # Specinfra::Backend::Ssh#build_command with custom sudo path command pattern 2a
rspec ./spec/backend/ssh/build_command_spec.rb:102 # Specinfra::Backend::Ssh#build_command without sudo command pattern 1b
rspec ./spec/backend/ssh/build_command_spec.rb:106 # Specinfra::Backend::Ssh#build_command without sudo command pattern 2b
rspec ./spec/backend/ssh/build_command_spec.rb:129 # Specinfra::Backend::Ssh#build_command with sudo on alternative path command pattern 1a is expected to eq "sudo -p 'Password: ' /bin/sh -c test\\ -f\\ /etc/passwd"
rspec ./spec/backend/ssh/build_command_spec.rb:134 # Specinfra::Backend::Ssh#build_command with sudo on alternative path command pattern 2a is expected to eq "sudo -p 'Password: ' /bin/sh -c test\\ \\!\\ -f\\ /etc/selinux/config\\ \\|\\|\\ \\(getenforce\\ \\|...\\ -i\\ --\\ disabled\\ \\&\\&\\ grep\\ -i\\ --\\ \\^SELINUX\\=disabled\\$\\ /etc/selinux/config\\)"
rspec ./spec/host_inventory/darwin/kernel_spec.rb:10 # Specinfra::HostInventory::Kernel get it includes the value of os_info[:arch] in the key 'machine'
```
