### PR TITLE
Add support for Kali Linux

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -206,6 +206,10 @@ require 'specinfra/command/debian/v8/port'
 require 'specinfra/command/devuan'
 require 'specinfra/command/devuan/base'
 
+# Kali Linux (inherit Debian)
+require 'specinfra/command/kali'
+require 'specinfra/command/kali/base'
+
 # Raspbian (inherit Debian)
 require 'specinfra/command/raspbian'
 

--- a/lib/specinfra/command/kali.rb
+++ b/lib/specinfra/command/kali.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Kali; end

--- a/lib/specinfra/command/kali/base.rb
+++ b/lib/specinfra/command/kali/base.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Kali::Base < Specinfra::Command::Debian::Base
+end


### PR DESCRIPTION
Should fix the following error on Kali Linux:

```
NameError:
  uninitialized constant Specinfra::Command::Kali
```