### PR TITLE
host_inventory/ohai: Suppress error messages to avoid parse error

### DIFF
--- a/lib/specinfra/host_inventory/ohai.rb
+++ b/lib/specinfra/host_inventory/ohai.rb
@@ -9,7 +9,7 @@ module Specinfra
         end
 
         begin
-          ret = backend.run_command('ohai --log_level error')
+          ret = backend.run_command('ohai --log_level error 2>/dev/null')
         rescue StandardError
           nil
         end


### PR DESCRIPTION
When `dmidecode` is not available on the host, `ohai` outputs the following error in addition to its JSON output.

```
$ ohai
[2026-07-04T21:32:52+09:00] ERROR: shard_seed: Failed to get dmi property serial_number: is dmidecode installed?
```

The above error is printed to stderr, but when `request_pty` is set to `true`, stderr is merged into stdout as discussed in the following issue:

 * https://github.com/net-ssh/net-ssh/issues/51

This causes JSON parse error and makes `host_inventory['ohai']` be `nil`. This PR fixes it by suppressing error messages.